### PR TITLE
Add platform check file to phar

### DIFF
--- a/src/Phar/Compiler.php
+++ b/src/Phar/Compiler.php
@@ -111,6 +111,7 @@ class Compiler
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_files.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_real.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_static.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/platform_check.php'));
         if (file_exists(__DIR__.'/../../vendor/composer/include_paths.php')) {
             $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/include_paths.php'));
         }


### PR DESCRIPTION
If I compile the phar file with `bin/compile` and execute the `docs.phar` file later. I got the error 

```
 failed to open stream: phar error: "vendor/composer/platform_check.php" is not a file in phar
 ```

Tested with latest composer version `2.0.12`