### PR TITLE
Prepare support for doctrine/rst-parser: 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": ">=7.4",
         "ext-json": "*",
         "ext-curl": "*",
-        "doctrine/rst-parser": "^0.4",
+        "doctrine/rst-parser": "^0.5",
         "scrivo/highlight.php": "^9.12.0",
         "symfony/filesystem": "^5.2",
         "symfony/finder": "^5.2",

--- a/src/BuildResult.php
+++ b/src/BuildResult.php
@@ -25,7 +25,10 @@ class BuildResult
     public function __construct(Builder $builder)
     {
         $this->builder = $builder;
-        $this->errors = $builder->getErrorManager()->getErrors();
+        $this->errors = [];
+        foreach ($builder->getErrorManager()->getErrors() as $error) {
+            $this->errors[] = $error->asString();
+        }
     }
 
     public function appendError(string $errorMessage): void

--- a/src/Command/BuildDocsCommand.php
+++ b/src/Command/BuildDocsCommand.php
@@ -80,6 +80,13 @@ class BuildDocsCommand extends Command
                 'Path where any errors should be saved'
             )
             ->addOption(
+                'error-output-format',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The output format for errors on std out',
+                Configuration::OUTPUT_FORMAT_CONSOLE
+            )
+            ->addOption(
                 'no-theme',
                 null,
                 InputOption::VALUE_NONE,
@@ -137,7 +144,9 @@ class BuildDocsCommand extends Command
             KernelFactory::createKernel($this->buildConfig, $this->urlChecker ?? null)
         );
 
-        $this->addProgressListener($builder->getConfiguration()->getEventManager());
+        $configuration = $builder->getConfiguration();
+        $configuration->setOutputFormat($input->getOption('error-output-format'));
+        $this->addProgressListener($configuration->getEventManager());
 
         $builder->build(
             $this->buildConfig->getContentDir(),
@@ -159,7 +168,7 @@ class BuildDocsCommand extends Command
             }
 
             $filesystem = new Filesystem();
-            $filesystem->dumpFile($logPath, implode("\n", $buildErrors));
+            $filesystem->dumpFile($logPath, implode("\n", array_map(fn($error) => is_string($error) ? $error : $error->asString(), $buildErrors)));
         }
 
         $metas = $builder->getMetas();


### PR DESCRIPTION
This will allow us to print errors on Github actions. 

We are blocked by a release of doctrine/rst-parser:0.5