### PR TITLE
Fixed the generation of TOCs

### DIFF
--- a/src/Twig/TocExtension.php
+++ b/src/Twig/TocExtension.php
@@ -24,10 +24,16 @@ class TocExtension extends AbstractExtension
     public static function getOptions(array $toc): array
     {
         $flattendToc = self::flattenToc($toc);
-        $maxDepth = 0;
+        // FIXME: this hardcoded '2' value should instead be obtained
+        // automatically using the 'maxdepth' option of 'toctree' directive.
+        // See https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
+        $maxDepth = 2;
         $numVisibleItems = 0;
         foreach ($flattendToc as $tocItem) {
-            $maxDepth = max($maxDepth, $tocItem['level']);
+            if ($tocItem['level'] > $maxDepth) {
+                continue;
+            }
+
             $numVisibleItems++;
         }
 


### PR DESCRIPTION
In some private tests we saw that a short TOC was displayed in two columns (as if it was a long TOC) whereas a slightly longer TOC was displayed in a single column.

The reason is that we were counting all TOC elements, instead of only the visible elements.

Please note that this PR is almost, but not entirely, correct. I had to hardcode the number of visible TOC levels at `2` (by far, the most common value in Symfony-related docs) but this should instead be obtained dynamically via the `maxdepth` TOC tree option in the RST contents.