### PR TITLE
Tweaked the prompts of console code blocks

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -74,8 +74,8 @@ class CodeNodeRenderer implements NodeRenderer
         }
 
         if ('terminal' === $language) {
-            $highlightedCode = preg_replace('/^\$/m', '<span class="hljs-prompt">$</span>', $highlightedCode);
-            $highlightedCode = preg_replace('/^C:\\\&gt;/m', '<span class="hljs-prompt">C:\&gt;</span>', $highlightedCode);
+            $highlightedCode = preg_replace('/^\$ /m', '<span class="hljs-prompt">$ </span>', $highlightedCode);
+            $highlightedCode = preg_replace('/^C:\\\&gt; /m', '<span class="hljs-prompt">C:\&gt; </span>', $highlightedCode);
         }
 
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -11,9 +11,9 @@
 2</pre>
        <pre class="codeblock-code">
            <code>
-               <span class="hljs-prompt">$</span> cowsay
+               <span class="hljs-prompt">$ </span>cowsay
                <span class="hljs-string">'eat more chicken'</span>
-               <span class="hljs-prompt">$</span> cowsay
+               <span class="hljs-prompt">$ </span>cowsay
                <span class="hljs-string">'mmmm'</span>
            </code>
        </pre>
@@ -27,7 +27,7 @@
 3</pre>
        <pre class="codeblock-code">
            <code>
-               <span class="hljs-prompt">C:\&gt;</span> CIV
+               <span class="hljs-prompt">C:\&gt; </span>CIV
                <span class="hljs-comment"># Civilization for DOS - my first computer game!</span>
            </code>
        </pre>


### PR DESCRIPTION
In code blocks that are consoles, we tweak the prompt a bit to make it not selectable. However, there's an extra white space. See:

![](https://user-images.githubusercontent.com/121003/124131097-7712f480-da4d-11eb-8b07-781fbfa6f2cb.png)

This PR changes it to look like this:

![](https://user-images.githubusercontent.com/73419/124267411-7f942980-db38-11eb-9222-fe07b9b80ac8.png)
