### PR TITLE
Update the attributes and classes of code blocks

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -79,18 +79,18 @@ class CodeNodeRenderer implements NodeRenderer
         }
 
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));
-        $lines = implode("\n", range(1, $numOfLines));
+        $lineNumbers = implode("\n", range(1, $numOfLines));
 
         return $this->templateRenderer->render(
             'code.html.twig',
             [
                 'languages' => $languages,
-                'lines' => $lines,
+                'line_numbers' => $lineNumbers,
                 'code' => $highlightedCode,
-                // this is the number of digits of the codeblock lines-of-code
-                // e.g. LOC = 5, digits = 1; LOC = 18, digits = 2
-                // this is useful to tweak the code listings according to their length
-                'numLocDigits' => strlen((string) $numOfLines),
+                'loc' => $numOfLines,
+                // the length of the codeblock in a semantic way (to tweak styling)
+                // e.g. LOC = 5, length = 'sm'; LOC = 18, length = 'md'
+                'length' => [1 => 'sm', 2 => 'md', 3 => 'lg', 4 => 'xl'][strlen((string) $numOfLines)],
             ]
         );
     }

--- a/src/Templates/default/html/code.html.twig
+++ b/src/Templates/default/html/code.html.twig
@@ -1,6 +1,6 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-{{ numLocDigits }} {{ languages|map(language => "codeblock-#{language}")|join(' ') }}">
+<div translate="no" data-loc="{{ loc }}" class="notranslate codeblock codeblock-length-{{ length }} {{ languages|map(language => "codeblock-#{language}")|join(' ') }}">
     <div class="codeblock-scroll">
-        <pre class="codeblock-lines">{{ lines }}</pre>
+        <pre class="codeblock-lines">{{ line_numbers }}</pre>
         <pre class="codeblock-code"><code>{{ code|raw }}</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-bash">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-bash">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code>git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/html-php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-php.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-html+php codeblock-html">
+<div translate="no" data-loc="12" class="notranslate codeblock codeblock-length-md codeblock-html+php codeblock-html">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html+twig codeblock-twig">
+<div translate="no" data-loc="2" class="notranslate codeblock codeblock-length-sm codeblock-html+twig codeblock-twig">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2</pre>

--- a/tests/fixtures/expected/blocks/code-blocks/html.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-html">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- some code --&gt;</span>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-ini">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-ini">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-attr">fetch</span> = +refs/notes/*:refs/notes/*</code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php-annotations codeblock-php">
+<div translate="no" data-loc="14" class="notranslate codeblock codeblock-length-md codeblock-php-annotations codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+<div translate="no" data-loc="7" class="notranslate codeblock codeblock-length-sm codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -1,11 +1,11 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-terminal codeblock-bash">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-terminal codeblock-bash">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code>git <span
             class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</code></pre>
     </div>
 </div>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-terminal codeblock-bash">
+<div translate="no" data-loc="2" class="notranslate codeblock codeblock-length-sm codeblock-terminal codeblock-bash">
    <div class="codeblock-scroll">
        <pre class="codeblock-lines">1
 2</pre>
@@ -20,7 +20,7 @@
    </div>
 </div>
 
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-terminal codeblock-bash">
+<div translate="no" data-loc="3" class="notranslate codeblock codeblock-length-sm codeblock-terminal codeblock-bash">
    <div class="codeblock-scroll">
        <pre class="codeblock-lines">1
 2

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-text">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-text">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code>some text</code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-twig">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-twig">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span></code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/xml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/xml.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-xml">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-xml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- some code --&gt;</span>

--- a/tests/fixtures/expected/blocks/code-blocks/yaml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/yaml.html
@@ -1,4 +1,4 @@
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-yaml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment"># some code</span>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -4,7 +4,7 @@
         <li data-language="php" > <span>PHP</span> </li>
     </ul>
     <div class="configuration-codeblock" data-language="yaml" style="">
-        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+        <div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-yaml">
             <div class="codeblock-scroll">
                 <pre class="codeblock-lines">1</pre>
                 <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/services.yml</span></code></pre>
@@ -12,7 +12,7 @@
         </div>
     </div>
     <div class="configuration-codeblock" data-language="php" style="display: none">
-        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+        <div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-php">
             <div class="codeblock-scroll">
                 <pre class="codeblock-lines">1</pre>
                 <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span></code></pre>

--- a/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
@@ -3,7 +3,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
         <span>Note</span>
     </p><p>test</p>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">// code</span>

--- a/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
@@ -1,5 +1,5 @@
 <div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title"><span>The sidebar's title</span></p><p>some text before code block</p>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">// some code</span>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -1,5 +1,5 @@
 <p>here is some php code from literal:</p>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+<div translate="no" data-loc="7" class="notranslate codeblock codeblock-length-sm codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -98,7 +98,7 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
 <p>If your widget option is set to <code translate="no" class="notranslate">choice</code>, then this field will be represented
 as a series of <code translate="no" class="notranslate">select</code> boxes. When the placeholder value is a string,
 it will be used as the <strong>blank value</strong> of all select boxes:</p>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+<div translate="no" data-loc="5" class="notranslate codeblock codeblock-length-sm codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -176,7 +176,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 <h3 id="error-bubbling"><a class="headerlink" href="#error-bubbling" title="Permalink to this headline">error_bubbling</a></h3>
 <p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
 <p>We also support code blocks!</p>
-<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+<div translate="no" data-loc="3" class="notranslate codeblock codeblock-length-sm codeblock-yaml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -195,7 +195,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
         <li data-language="php" > <span>PHP</span> </li>
     </ul>
     <div class="configuration-codeblock" data-language="yaml" style="">
-        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+        <div translate="no" data-loc="7" class="notranslate codeblock codeblock-length-sm codeblock-yaml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -216,7 +216,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </div>
         </div>
         <div class="configuration-codeblock" data-language="xml" style="display: none">
-            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-xml">
+            <div translate="no" data-loc="20" class="notranslate codeblock codeblock-length-md codeblock-xml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -263,7 +263,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </div>
         </div>
         <div class="configuration-codeblock" data-language="php" style="display: none">
-            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php">
+            <div translate="no" data-loc="10" class="notranslate codeblock codeblock-length-md codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2


### PR DESCRIPTION
I know I changed this lots of times ... sorry 🙏  ... but I think I finally got it right.

This adds both a semantic class related to the code length (e.g. `codeblock-length-sm`) to tweak its styling as well as an HTML attribute with the exact number of lines of code (e.g. `data-loc="17"`) which we need for very special styling (e.g. code "blocks" of just 1 line) and for dynamic JS features (e.g. hide long listings and show a message saying "click to see the other 35 lines").