### PR TITLE
Fix a formatting issue in definition lists

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -124,8 +124,20 @@ class IntegrationTest extends AbstractIntegrationTest
             'blockName' => 'nodes/literal',
         ];
 
-        yield 'list' => [
-            'blockName' => 'nodes/list',
+        yield 'unordered-list' => [
+            'blockName' => 'nodes/unordered-list',
+        ];
+
+        yield 'ordered-list' => [
+            'blockName' => 'nodes/ordered-list',
+        ];
+
+        yield 'definition-list' => [
+            'blockName' => 'nodes/definition-list',
+        ];
+
+        yield 'list-with-formatting' => [
+            'blockName' => 'nodes/list-with-formatting',
         ];
 
         yield 'figure' => [

--- a/tests/fixtures/expected/blocks/nodes/definition-list.html
+++ b/tests/fixtures/expected/blocks/nodes/definition-list.html
@@ -1,0 +1,10 @@
+<dl>
+    <dt>Sed do eiusmod</dt>
+    <dd> Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam. </dd>
+
+    <dt>Quis nostrud</dt>
+    <dd> Exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </dd>
+
+    <dt>Duis aute irure</dt>
+    <dd> Dolor in reprehenderit in voluptate velit esse. </dd>
+</dl>

--- a/tests/fixtures/expected/blocks/nodes/list-with-formatting.html
+++ b/tests/fixtures/expected/blocks/nodes/list-with-formatting.html
@@ -1,0 +1,24 @@
+<ul>
+    <li>List <strong>item 1</strong></li>
+    <li><code translate="no" class="notranslate">List</code> item 2</li>
+    <li><em>List</em> item 3</li>
+    <li>List item 4</li>
+</ul>
+
+<ol class="arabic">
+    <li>List <strong>item 1</strong></li>
+    <li><code translate="no" class="notranslate">List</code> item 2</li>
+    <li><em>List</em> item 3</li>
+    <li>List item 4</li>
+</ol>
+
+<dl>
+    <dt><strong>Quis:</strong> <code translate="no" class="notranslate">int[]</code></dt>
+    <dd>Exercitation ullamco <em>laboris nisi</em> ut aliquip ex ea commodo consequat.</dd>
+
+    <dt><code translate="no" class="notranslate">Sed do eiusmod</code></dt>
+    <dd> Tempor <code translate="no" class="notranslate">incididunt</code> ut <em>labore</em> et dolore magna aliqua. Ut enim ad minim veniam. </dd>
+
+    <dt>Duis <em>aute irure</em></dt>
+    <dd> Dolor in <strong>reprehenderit</strong> in voluptate velit esse. </dd>
+</dl>

--- a/tests/fixtures/expected/blocks/nodes/list.html
+++ b/tests/fixtures/expected/blocks/nodes/list.html
@@ -1,5 +1,0 @@
-<ul><li>List item 1</li>
-<li>List item 2</li>
-<li>List item 3</li>
-<li>List item 4</li>
-</ul>

--- a/tests/fixtures/expected/blocks/nodes/ordered-list.html
+++ b/tests/fixtures/expected/blocks/nodes/ordered-list.html
@@ -1,0 +1,13 @@
+<ol class="arabic">
+    <li>List item 1</li>
+    <li>List item 2</li>
+    <li>List item 3</li>
+    <li>List item 4</li>
+</ol>
+
+<ol class="arabic">
+    <li>List item 1</li>
+    <li>List item 2</li>
+    <li>List item 3</li>
+    <li>List item 4</li>
+</ol>

--- a/tests/fixtures/expected/blocks/nodes/unordered-list.html
+++ b/tests/fixtures/expected/blocks/nodes/unordered-list.html
@@ -1,0 +1,13 @@
+<ul>
+    <li>List item 1</li>
+    <li>List item 2</li>
+    <li>List item 3</li>
+    <li>List item 4</li>
+</ul>
+
+<ul>
+    <li>List item 1</li>
+    <li>List item 2</li>
+    <li>List item 3</li>
+    <li>List item 4</li>
+</ul>

--- a/tests/fixtures/source/blocks/nodes/definition-list.rst
+++ b/tests/fixtures/source/blocks/nodes/definition-list.rst
@@ -1,0 +1,9 @@
+
+Sed do eiusmod
+    Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+
+Quis nostrud
+    Exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure
+    Dolor in reprehenderit in voluptate velit esse.

--- a/tests/fixtures/source/blocks/nodes/list-with-formatting.rst
+++ b/tests/fixtures/source/blocks/nodes/list-with-formatting.rst
@@ -1,0 +1,18 @@
+* List **item 1**
+* ``List`` item 2
+* *List* item 3
+* List item 4
+
+#. List **item 1**
+#. ``List`` item 2
+#. *List* item 3
+#. List item 4
+
+**Quis:** ``int[]``
+    Exercitation ullamco *laboris nisi* ut aliquip ex ea commodo consequat.
+
+``Sed do eiusmod``
+    Tempor ``incididunt`` ut *labore* et dolore magna aliqua. Ut enim ad minim veniam.
+
+Duis *aute irure*
+    Dolor in **reprehenderit** in voluptate velit esse.

--- a/tests/fixtures/source/blocks/nodes/ordered-list.rst
+++ b/tests/fixtures/source/blocks/nodes/ordered-list.rst
@@ -1,0 +1,10 @@
+
+#. List item 1
+#. List item 2
+#. List item 3
+#. List item 4
+
+1. List item 1
+2. List item 2
+3. List item 3
+4. List item 4

--- a/tests/fixtures/source/blocks/nodes/unordered-list.rst
+++ b/tests/fixtures/source/blocks/nodes/unordered-list.rst
@@ -3,3 +3,8 @@
 - List item 2
 - List item 3
 - List item 4
+
+* List item 1
+* List item 2
+* List item 3
+* List item 4


### PR DESCRIPTION
This PR adds more tests related to lists and **adds a failing test** for some bug that I've found. I don't know how to solve this, so **I need your help**. Thanks!

-----

In the docs of LiipImagineBundle I've found this error. Above you see the original RST content and below the rendered HTML, which is wrong:

![](https://user-images.githubusercontent.com/73419/124734173-2734a180-df15-11eb-9359-bb71db302606.png)

The `** ... **` should instead be a bold text `<strong> ... </strong>`.

The failing test shows this problem well:

```diff
--- Expected
+++ Actual
@@ @@
 <dl>
-    <dt><strong>Quis:</strong> <code translate="no" class="notranslate">int[]</code></dt>
+    <dt>
+        **Quis
+        <span class="classifier-delimiter">:</span>
+        <span class="classifier">** <code translate="no" class="notranslate">int[]</code></span>
+    </dt>
```