### PR TITLE
Don't output errors

### DIFF
--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -29,6 +29,8 @@ final class KernelFactory
     public static function createKernel(BuildConfig $buildConfig, ?UrlChecker $urlChecker = null): Kernel
     {
         $configuration = new RSTParserConfiguration();
+        // needed to avoid outputting parser errors on the console output or the webpage contents
+        $configuration->silentOnError(true);
         $configuration->setCustomTemplateDirs([__DIR__.'/Templates']);
         $configuration->setTheme($buildConfig->getTheme());
         $configuration->setCacheDir(sprintf('%s/var/cache', $buildConfig->getCacheDir()));


### PR DESCRIPTION
This change is needed because otherwise, this happens:

https://github.com/doctrine/rst-parser/blob/54024026d64fff84de645537015e30709a123ab1/lib/ErrorManager.php#L27-L29

This `echo` outputs the errors to the console, which is not that bad ... but also to the webpage contents (e.g. when using #109 to parse RST blog posts).

We manage the build results and the errors explicitly, so we don't need this for Symfony docs. Thanks!