### PR TITLE
Add a test for headless tables with leading space

### DIFF
--- a/tests/fixtures/source/blocks/nodes/tables.rst
+++ b/tests/fixtures/source/blocks/nodes/tables.rst
@@ -14,6 +14,13 @@ Simple table headless:
 /foo/       It makes a 301 redirect to /foo/          It matches (200 status response)
 ==========  ========================================  ==========================================
 
+Simple table headless with leading whitespace:
+
+==========  ========================================  ==========================================
+      /foo  It matches (200 status response)          It doesn't match (404 status response)
+     /foo/  It makes a 301 redirect to /foo/          It matches (200 status response)
+==========  ========================================  ==========================================
+
 Grid table:
 
 +--------+------------+


### PR DESCRIPTION
In some Symfony Docs we have this use case. That's why I'm adding this failing test. For now I've updated the table to not have leading white space (i.e. turn right-aligned contents into left-aligned contents).

If this is easy to solve, maybe we should to it for completeness sake ... otherwise, let's forget about this edge-case. Thanks!