### PR TITLE
Add a failing test about diff code highlighting

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -260,6 +260,10 @@ if(str_contains($expectedFile, 'datetime.html')) {
             'blockName' => 'code-blocks/bash',
         ];
 
+        yield 'code-block-diff' => [
+            'blockName' => 'code-blocks/diff',
+        ];
+
         yield 'code-block-html-php' => [
             'blockName' => 'code-blocks/html-php',
         ];

--- a/tests/fixtures/expected/blocks/code-blocks/diff.html
+++ b/tests/fixtures/expected/blocks/code-blocks/diff.html
@@ -1,0 +1,39 @@
+<div translate="no" data-loc="5" class="notranslate codeblock codeblock-length-sm codeblock-diff">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5</pre>
+        <pre class="codeblock-code">
+            <code>
+                <span class="hljs-addition">+ Added line</span>
+                <span class="hljs-deletion">- Removed line</span>
+                Normal line
+<span class="hljs-deletion">- Removed line</span>
+                <span class="hljs-addition">+ Added line</span>
+            </code>
+        </pre>
+    </div>
+</div>
+
+<div translate="no" data-loc="6" class="notranslate codeblock codeblock-length-sm codeblock-diff">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6</pre>
+        <pre class="codeblock-code">
+            <code>
+                Normal line
+<span class="hljs-addition">+ Added line</span>
+                <span class="hljs-deletion">- Removed line</span>
+                Normal line
+<span class="hljs-deletion">- Removed line</span>
+                <span class="hljs-addition">+ Added line</span>
+            </code>
+        </pre>
+    </div>
+</div>

--- a/tests/fixtures/source/blocks/code-blocks/diff.rst
+++ b/tests/fixtures/source/blocks/code-blocks/diff.rst
@@ -1,0 +1,18 @@
+
+.. code-block:: diff
+
+    + Added line
+    - Removed line
+      Normal line
+    - Removed line
+    + Added line
+
+
+.. code-block:: diff
+
+      Normal line
+    + Added line
+    - Removed line
+      Normal line
+    - Removed line
+    + Added line


### PR DESCRIPTION
@wouterj reported that a code block here https://symfony.com/doc/current/security.html#form-login didn't show any highlighting.

It's true. The problem occurs when a `diff` code block doesn't start its first line with `+` or `-` In this failing test, the first code block works but the second doesn't ~(to be completely honest, the first one doesn't work either because of some white space issue which I can't see, but it mostly works)~ <-- this problem was fixed by Ryan. Thanks!