### PR TITLE
Process sidebar directive's titles as span nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /docs.phar
 /.env
 /.phpunit.result.cache
+/composer.lock

--- a/src/Directive/SidebarDirective.php
+++ b/src/Directive/SidebarDirective.php
@@ -25,7 +25,7 @@ class SidebarDirective extends SubDirective
         $wrapperDiv = $parser->renderTemplate(
             'directives/sidebar.html.twig',
             [
-                'title' => $data,
+                'title' => $parser->createSpanNode($data)->render(),
             ]
         );
 

--- a/tests/fixtures/expected/blocks/directives/sidebar.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar.html
@@ -1,2 +1,5 @@
 <div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title"><span>The sidebar's title</span></p><p>some text inside sidebar</p>
 </div></div>
+
+<div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title"><span>More about the <code translate="no" class="notranslate">request()</code> Method</span></p><p>The full signature of the <code translate="no" class="notranslate">request()</code> method is...</p>
+</div></div>

--- a/tests/fixtures/source/blocks/directives/sidebar.rst
+++ b/tests/fixtures/source/blocks/directives/sidebar.rst
@@ -2,3 +2,7 @@
 .. sidebar:: The sidebar's title
 
     some text inside sidebar
+
+.. sidebar:: More about the ``request()`` Method
+
+    The full signature of the ``request()`` method is...


### PR DESCRIPTION
Fixes #115 

I've also added `composer.lock` to the gitignore, not sure why it wasn't in there already.