### PR TITLE
Add a failing test about email links

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -136,6 +136,10 @@ if(str_contains($expectedFile, 'datetime.html')) {
             'blockName' => 'nodes/list',
         ];
 
+        yield 'email' => [
+            'blockName' => 'nodes/email',
+        ];
+
         yield 'figure' => [
             'blockName' => 'nodes/figure',
         ];

--- a/tests/fixtures/expected/blocks/nodes/email.html
+++ b/tests/fixtures/expected/blocks/nodes/email.html
@@ -1,0 +1,17 @@
+<p>Lorem ipsum dolor sit amet <a href="mailto:user@example.com" class="reference internal">user@example.com</a> consectetur adipisicing elit.</p>
+
+<p>Lorem ipsum dolor sit amet <strong><a href="mailto:user@example.com" class="reference internal">user@example.com</a></strong> consectetur adipisicing elit.</p>
+
+<p>
+    Lorem ipsum dolor
+    <strong>sit amet <a href="mailto:user@example.com" class="reference internal">user@example.com</a> consectetur</strong>
+    adipisicing elit.
+</p>
+
+<p>Lorem ipsum dolor sit amet <em><a href="mailto:user@example.com" class="reference internal">user@example.com</a></em> consectetur adipisicing elit.</p>
+
+<p>
+    Lorem ipsum dolor
+    <em>sit amet <a href="mailto:user@example.com" class="reference internal">user@example.com</a> consectetur</em>
+    adipisicing elit.
+</p>

--- a/tests/fixtures/source/blocks/nodes/email.rst
+++ b/tests/fixtures/source/blocks/nodes/email.rst
@@ -1,0 +1,9 @@
+Lorem ipsum dolor sit amet user@example.com consectetur adipisicing elit.
+
+Lorem ipsum dolor sit amet **user@example.com** consectetur adipisicing elit.
+
+Lorem ipsum dolor **sit amet user@example.com consectetur** adipisicing elit.
+
+Lorem ipsum dolor sit amet *user@example.com* consectetur adipisicing elit.
+
+Lorem ipsum dolor *sit amet user@example.com consectetur* adipisicing elit.


### PR DESCRIPTION
If you look at the first paragraph of this section: https://symfony.com/doc/current/contributing/code_of_conduct/care_team.html#members you'll see an error with some bold text and an email link.

In this failing test, all cases work except `**user@example.com**` and `*user@example.com*`

If it's complicated to make it work, let's reword the docs to not use that syntax. Thanks!