### PR TITLE
Improve copy/paste of diff code blocks

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -78,6 +78,17 @@ class CodeNodeRenderer implements NodeRenderer
             $highlightedCode = preg_replace('/^C:\\\&gt; /m', '<span class="hljs-prompt">C:\&gt; </span>', $highlightedCode);
         }
 
+        if ('diff' === $language) {
+            // remove the '+' and '-' signs so they can be added with css
+            $highlightedCode = str_replace([
+                '<span class="hljs-deletion">-',
+                '<span class="hljs-addition">+',
+            ], [
+                '<span class="hljs-deletion"> ',
+                '<span class="hljs-addition"> ',
+            ], $highlightedCode);
+        }
+
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));
         $lineNumbers = implode("\n", range(1, $numOfLines));
 

--- a/src/Templates/rtd/assets/css/highlightjs.css
+++ b/src/Templates/rtd/assets/css/highlightjs.css
@@ -66,3 +66,16 @@ Visual Studio-like style based on original C# coloring by Jason Diamond <jason@d
 .hljs-strong {
   font-weight: bold;
 }
+
+.hljs-addition::before,
+.hljs-deletion::before {
+  position: absolute;
+}
+
+.hljs-addition::before {
+  content: '+';
+}
+
+.hljs-deletion::before {
+  content: '-';
+}

--- a/tests/fixtures/expected/blocks/code-blocks/diff.html
+++ b/tests/fixtures/expected/blocks/code-blocks/diff.html
@@ -7,11 +7,11 @@
 5</pre>
         <pre class="codeblock-code">
             <code>
-                <span class="hljs-addition">+ Added line</span>
-                <span class="hljs-deletion">- Removed line</span>
+                <span class="hljs-addition">  Added line</span>
+                <span class="hljs-deletion">  Removed line</span>
                 Normal line
-<span class="hljs-deletion">- Removed line</span>
-                <span class="hljs-addition">+ Added line</span>
+<span class="hljs-deletion">  Removed line</span>
+                <span class="hljs-addition">  Added line</span>
             </code>
         </pre>
     </div>
@@ -28,11 +28,11 @@
         <pre class="codeblock-code">
             <code>
                 Normal line
-<span class="hljs-addition">+ Added line</span>
-                <span class="hljs-deletion">- Removed line</span>
+<span class="hljs-addition">  Added line</span>
+                <span class="hljs-deletion">  Removed line</span>
                 Normal line
-<span class="hljs-deletion">- Removed line</span>
-                <span class="hljs-addition">+ Added line</span>
+<span class="hljs-deletion">  Removed line</span>
+                <span class="hljs-addition">  Added line</span>
             </code>
         </pre>
     </div>


### PR DESCRIPTION
Currently, copy-pasting code from diff blocks also copies the `+` & `-` signs, which can be really annoying. The idea here is to remove those signs from the html & add them via css & the `::before` pseudo element. This way the signs don't get copied with the rest of the code.

![screen-copy](https://user-images.githubusercontent.com/2445045/141661496-c6f6fd13-b525-4bbe-ae08-f0774b60d17a.gif)
