### PR TITLE
Include all required options for a successful symfony-docs build

### DIFF
--- a/bin/docs-builder
+++ b/bin/docs-builder
@@ -16,7 +16,7 @@ foreach ($autoloadFiles as $autoloadFile) {
 use Symfony\Component\Console\Input\ArgvInput;
 use SymfonyDocsBuilder\Application;
 
-$input       = new ArgvInput();
+$input   = new ArgvInput();
 $version = $input->getParameterOption(['--symfony-version'], false === getenv('SYMFONY_VERSION') ? 'master' : getenv('SYMFONY_VERSION'));
 
 if (!$version) {

--- a/src/ConfigFileParser.php
+++ b/src/ConfigFileParser.php
@@ -2,37 +2,36 @@
 
 namespace SymfonyDocsBuilder;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * Parses the docs.json config file
  */
 class ConfigFileParser
 {
     private $buildConfig;
-    private $output;
 
-    public function __construct(BuildConfig $buildConfig, OutputInterface $output)
+    public function __construct(BuildConfig $buildConfig)
     {
         $this->buildConfig = $buildConfig;
-        $this->output = $output;
     }
 
-    public function processConfigFile(string $sourceDir): void
+    public function processConfigFile(string $configPath): void
     {
-        $configPath = $sourceDir.'/docs.json';
         if (!file_exists($configPath)) {
-            $this->output->writeln(sprintf('No config file present at <info>%s</info>', $configPath));
+            throw new \RuntimeException(sprintf('No config file present at <info>%s</info>', $configPath));
 
             return;
         }
 
-        $this->output->writeln(sprintf('Loading config file: <info>%s</info>', $configPath));
         $configData = json_decode(file_get_contents($configPath), true);
 
         $exclude = $configData['exclude'] ?? [];
         $this->buildConfig->setExcludedPaths($exclude);
         unset($configData['exclude']);
+
+        if ($sfVersion = $configData['symfony-version'] ?? false) {
+            $this->buildConfig->setSymfonyVersion($sfVersion);
+        }
+        unset($configData['symfony-version']);
 
         if (count($configData) > 0) {
             throw new \Exception(sprintf('Unsupported keys in docs.json: %s', implode(', ', array_keys($configData))));


### PR DESCRIPTION
This modifies the script so that it can be run without any customization in the symfony-docs repository.

Having all PHP code of the docs builder in 1 repository means that we can more easily update the script in case of BC breaks (which will happen, as this package is internal).