### PR TITLE
Tweak the feature that links to Symfony repository URLs

### DIFF
--- a/src/BuildConfig.php
+++ b/src/BuildConfig.php
@@ -16,7 +16,7 @@ use Symfony\Component\Finder\Finder;
 class BuildConfig
 {
     private const PHP_DOC_URL = 'https://secure.php.net/manual/en';
-    private const GITHUB_URL = 'https://github.com/symfony/symfony/blob/{symfonyVersion}/src';
+    private const SYMFONY_REPOSITORY_URL = 'https://github.com/symfony/symfony/blob/{symfonyVersion}/src';
     private const SYMFONY_DOC_URL = 'https://symfony.com/doc/{symfonyVersion}';
 
     private $useBuildCache;
@@ -78,9 +78,9 @@ class BuildConfig
         return self::PHP_DOC_URL;
     }
 
-    public function getGithubUrl(): string
+    public function getSymfonyRepositoryUrl(): string
     {
-        return str_replace('{symfonyVersion}', $this->getSymfonyVersion(), self::GITHUB_URL);
+        return str_replace('{symfonyVersion}', $this->getSymfonyVersion(), self::SYMFONY_REPOSITORY_URL);
     }
 
     public function getSymfonyDocUrl(): string

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -101,9 +101,9 @@ final class KernelFactory
     private static function getReferences(BuildConfig $buildConfig): array
     {
         return [
-            new SymfonyReferences\ClassReference($buildConfig->getGithubUrl()),
-            new SymfonyReferences\MethodReference($buildConfig->getGithubUrl()),
-            new SymfonyReferences\NamespaceReference($buildConfig->getGithubUrl()),
+            new SymfonyReferences\ClassReference($buildConfig->getSymfonyRepositoryUrl()),
+            new SymfonyReferences\MethodReference($buildConfig->getSymfonyRepositoryUrl()),
+            new SymfonyReferences\NamespaceReference($buildConfig->getSymfonyRepositoryUrl()),
             new SymfonyReferences\PhpFunctionReference($buildConfig->getPhpDocUrl()),
             new SymfonyReferences\PhpMethodReference($buildConfig->getPhpDocUrl()),
             new SymfonyReferences\PhpClassReference($buildConfig->getPhpDocUrl()),

--- a/src/Reference/ClassReference.php
+++ b/src/Reference/ClassReference.php
@@ -16,11 +16,11 @@ use function Symfony\Component\String\u;
 
 class ClassReference extends Reference
 {
-    private $githubUrl;
+    private $symfonyRepositoryUrl;
 
-    public function __construct(string $githubUrl)
+    public function __construct(string $symfonyRepositoryUrl)
     {
-        $this->githubUrl = $githubUrl;
+        $this->symfonyRepositoryUrl = $symfonyRepositoryUrl;
     }
 
     public function getName(): string
@@ -35,7 +35,7 @@ class ClassReference extends Reference
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $className->afterLast('\\'),
-            sprintf('%s/%s.php', $this->githubUrl, $className->replace('\\', '/')),
+            sprintf('%s/%s.php', $this->symfonyRepositoryUrl, $className->replace('\\', '/')),
             [],
             [
                 'title' => $className,

--- a/src/Reference/MethodReference.php
+++ b/src/Reference/MethodReference.php
@@ -16,11 +16,11 @@ use function Symfony\Component\String\u;
 
 class MethodReference extends Reference
 {
-    private $githubUrl;
+    private $symfonyRepositoryUrl;
 
-    public function __construct(string $githubUrl)
+    public function __construct(string $symfonyRepositoryUrl)
     {
-        $this->githubUrl = $githubUrl;
+        $this->symfonyRepositoryUrl = $symfonyRepositoryUrl;
     }
 
     public function getName(): string
@@ -42,7 +42,7 @@ class MethodReference extends Reference
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $methodName.'()',
-            sprintf('%s/%s.php#method_%s', $this->githubUrl, str_replace('\\', '/', $className), $methodName),
+            sprintf('%s/%s.php#method_%s', $this->symfonyRepositoryUrl, str_replace('\\', '/', $className), $methodName),
             [],
             [
                 'title' => sprintf('%s::%s()', $className, $methodName),

--- a/src/Reference/NamespaceReference.php
+++ b/src/Reference/NamespaceReference.php
@@ -16,11 +16,11 @@ use function Symfony\Component\String\u;
 
 class NamespaceReference extends Reference
 {
-    private $githubUrl;
+    private $symfonyRepositoryUrl;
 
-    public function __construct(string $githubUrl)
+    public function __construct(string $symfonyRepositoryUrl)
     {
-        $this->githubUrl = $githubUrl;
+        $this->symfonyRepositoryUrl = $symfonyRepositoryUrl;
     }
 
     public function getName(): string
@@ -35,7 +35,7 @@ class NamespaceReference extends Reference
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $className->afterLast('\\'),
-            sprintf('%s/%s', $this->githubUrl, $className->replace('\\', '/')),
+            sprintf('%s/%s', $this->symfonyRepositoryUrl, $className->replace('\\', '/')),
             [],
             [
                 'title' => $className,


### PR DESCRIPTION
#136 was a very nice fix from Wouter, but I find the `GITHUB_URL` constant name too generic. Since we already have a `SYMFONY_DOC_URL`, I propose to rename it to `SYMFONY_REPOSITORY_URL`.