### PR TITLE
fix: escape special chars in code text

### DIFF
--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -1,6 +1,6 @@
 <div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-text">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code>some text</code></pre>
+        <pre class="codeblock-code"><code>some text with special chars &lt; &gt; " &amp; and some text with special chars already escaped &lt; &gt; " &amp;</code></pre>
     </div>
 </div>

--- a/tests/fixtures/source/blocks/code-blocks/text.rst
+++ b/tests/fixtures/source/blocks/code-blocks/text.rst
@@ -1,3 +1,3 @@
 
 .. code-block:: text
-    some text
+    some text with special chars < > " & and some text with special chars already escaped &lt; &gt; &quot; &amp;


### PR DESCRIPTION
Hello there!

here is a fix for https://github.com/symfony/symfony-docs/pull/17587

I had hard time understanding the problem was only occurring for code of type "text"!

cheers!
