### PR TITLE
Replace `{version}` in URLs

### DIFF
--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -44,7 +44,8 @@ final class KernelFactory
             new SymfonyHTMLFormat(
                 $configuration->getTemplateRenderer(),
                 $configuration->getFormat(),
-                $urlChecker
+                $urlChecker,
+                $buildConfig->getSymfonyVersion()
             )
         );
 

--- a/src/Renderers/SpanNodeRenderer.php
+++ b/src/Renderers/SpanNodeRenderer.php
@@ -25,23 +25,27 @@ class SpanNodeRenderer extends AbstractSpanNodeRenderer
     private $decoratedSpanNodeRenderer;
     /** @var UrlChecker|null */
     private $urlChecker;
+    private $symfonyVersion;
 
     public function __construct(
         Environment $environment,
         SpanNode $span,
         BaseSpanNodeRenderer $decoratedSpanNodeRenderer,
-        ?UrlChecker $urlChecker = null
-    ) {
+        ?UrlChecker $urlChecker = null,
+        string $symfonyVersion = null
+    )
+    {
         parent::__construct($environment, $span);
 
         $this->decoratedSpanNodeRenderer = $decoratedSpanNodeRenderer;
         $this->urlChecker = $urlChecker;
+        $this->symfonyVersion = $symfonyVersion;
     }
 
     /** @inheritDoc */
     public function link(?string $url, string $title, array $attributes = []): string
     {
-        $url = (string)$url;
+        $url = (string) $url;
 
         if (
             $this->urlChecker &&
@@ -53,6 +57,10 @@ class SpanNodeRenderer extends AbstractSpanNodeRenderer
 
         if (!$this->isSafeUrl($url)) {
             $attributes = $this->addAttributesForUnsafeUrl($attributes);
+        }
+
+        if (null !== $this->symfonyVersion) {
+            $url = u($url)->replace('{version}', $this->symfonyVersion)->toString();
         }
 
         return $this->decoratedSpanNodeRenderer->link($url, $title, $attributes);

--- a/src/SymfonyHTMLFormat.php
+++ b/src/SymfonyHTMLFormat.php
@@ -29,12 +29,14 @@ final class SymfonyHTMLFormat implements Format
     private $htmlFormat;
     /** @var UrlChecker|null */
     private $urlChecker;
+    private $symfonyVersion;
 
-    public function __construct(TemplateRenderer $templateRenderer, Format $HTMLFormat, ?UrlChecker $urlChecker = null)
+    public function __construct(TemplateRenderer $templateRenderer, Format $HTMLFormat, ?UrlChecker $urlChecker = null, string $symfonyVersion = null)
     {
         $this->templateRenderer = $templateRenderer;
         $this->htmlFormat = $HTMLFormat;
         $this->urlChecker = $urlChecker;
+        $this->symfonyVersion = $symfonyVersion;
     }
 
     public function getFileExtension(): string
@@ -69,7 +71,8 @@ final class SymfonyHTMLFormat implements Format
                     $node->getEnvironment(),
                     $node,
                     new BaseSpanNodeRenderer($node->getEnvironment(), $node, $this->templateRenderer),
-                    $this->urlChecker
+                    $this->urlChecker,
+                    $this->symfonyVersion
                 );
             }
         );

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -143,6 +143,10 @@ if(str_contains($expectedFile, 'datetime.html')) {
             'blockName' => 'nodes/figure',
         ];
 
+        yield 'span-link' => [
+            'blockName' => 'nodes/span-link',
+        ];
+
         yield 'title' => [
             'blockName' => 'nodes/title',
         ];

--- a/tests/fixtures/expected/blocks/nodes/span-link.html
+++ b/tests/fixtures/expected/blocks/nodes/span-link.html
@@ -1,0 +1,3 @@
+<p><a href="https://github.com/symfony/amazon-sns-notifier/blob/4.0/README.md" class="reference external" rel="external noopener noreferrer" target="_blank">README file with version substitution</a></p>
+
+<p><a href="https://github.com/symfony/amazon-sns-notifier/blob/version/README.md" class="reference external" rel="external noopener noreferrer" target="_blank">README file without version substitution</a></p>

--- a/tests/fixtures/source/blocks/nodes/span-link.rst
+++ b/tests/fixtures/source/blocks/nodes/span-link.rst
@@ -1,0 +1,3 @@
+`README file with version substitution <https://github.com/symfony/amazon-sns-notifier/blob/{version}/README.md>`_
+
+`README file without version substitution <https://github.com/symfony/amazon-sns-notifier/blob/version/README.md>`_


### PR DESCRIPTION
In order to make link on symfony codebase, even if is not a class or a method reference

Can be usefull in this case for example https://github.com/symfony/symfony-docs/pull/17902