### PR TITLE
Avoid link with same ID's

### DIFF
--- a/src/Renderers/TitleNodeRenderer.php
+++ b/src/Renderers/TitleNodeRenderer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Renderers;
+
+use Doctrine\RST\Environment;
+use Doctrine\RST\Nodes\TitleNode;
+use Doctrine\RST\Renderers\NodeRenderer;
+use Doctrine\RST\Templates\TemplateRenderer;
+
+class TitleNodeRenderer implements NodeRenderer
+{
+    /** @var TitleNode */
+    private $titleNode;
+
+    /** @var TemplateRenderer */
+    private $templateRenderer;
+
+    private static $idUsagesCountByFilename = [];
+
+    public function __construct(TitleNode $titleNode, TemplateRenderer $templateRenderer)
+    {
+        $this->titleNode = $titleNode;
+        $this->templateRenderer = $templateRenderer;
+    }
+
+    public function render(): string
+    {
+        $filename = $this->titleNode->getEnvironment()->getCurrentFileName();
+        $id = $this->titleNode->getId();
+
+        $idUsagesCount = self::$idUsagesCountByFilename[$filename][$id] ?? 0;
+
+        if (0 === $idUsagesCount) {
+            $computedId = $this->titleNode->getId();
+        } else {
+            $computedId = Environment::slugify($this->titleNode->getValue()->getText().'-'.$idUsagesCount);
+        }
+
+        self::$idUsagesCountByFilename[$filename][$id] = $idUsagesCount + 1;
+
+        return $this->templateRenderer->render('header-title.html.twig', [
+            'titleNode' => $this->titleNode,
+            'id' => $computedId,
+        ]);
+    }
+}

--- a/src/SymfonyHTMLFormat.php
+++ b/src/SymfonyHTMLFormat.php
@@ -14,6 +14,7 @@ namespace SymfonyDocsBuilder;
 use Doctrine\RST\Formats\Format;
 use Doctrine\RST\Nodes\CodeNode;
 use Doctrine\RST\Nodes\SpanNode;
+use Doctrine\RST\Nodes\TitleNode;
 use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
@@ -73,6 +74,15 @@ final class SymfonyHTMLFormat implements Format
                     new BaseSpanNodeRenderer($node->getEnvironment(), $node, $this->templateRenderer),
                     $this->urlChecker,
                     $this->symfonyVersion
+                );
+            }
+        );
+
+        $nodeRendererFactories[TitleNode::class] = new CallableNodeRendererFactory(
+            function (TitleNode $node) {
+                return new Renderers\TitleNodeRenderer(
+                    $node,
+                    $this->templateRenderer
                 );
             }
         );

--- a/src/Templates/default/html/header-title.html.twig
+++ b/src/Templates/default/html/header-title.html.twig
@@ -1,1 +1,1 @@
-<h{{ titleNode.level }} id="{{ titleNode.id }}"><a class="headerlink" href="#{{ titleNode.id }}" title="Permalink to this headline">{{ titleNode.value.render()|raw }}</a></h{{ titleNode.level }}>
+<h{{ titleNode.level }} id="{{ id }}"><a class="headerlink" href="#{{ id }}" title="Permalink to this headline">{{ titleNode.value.render()|raw }}</a></h{{ titleNode.level }}>

--- a/src/Templates/rtd/html/header-title.html.twig
+++ b/src/Templates/rtd/html/header-title.html.twig
@@ -1,4 +1,4 @@
-<h{{ titleNode.level }} id="{{ titleNode.id }}">
+<h{{ titleNode.level }} id="{{ id }}">
     {{ titleNode.value.render()|raw }}
-    <a class="headerlink" href="#{{ titleNode.id }}" title="Permalink to this headline">¶</a>
+    <a class="headerlink" href="#{{ id }}" title="Permalink to this headline">¶</a>
 </h{{ titleNode.level }}>

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -17,9 +17,19 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Finder\Finder;
 use SymfonyDocsBuilder\DocBuilder;
 use SymfonyDocsBuilder\KernelFactory;
+use SymfonyDocsBuilder\Renderers\TitleNodeRenderer;
 
 class IntegrationTest extends AbstractIntegrationTest
 {
+    public static function setUpBeforeClass(): void
+    {
+        $reflection = new \ReflectionClass(TitleNodeRenderer::class);
+        $property = $reflection->getProperty('idUsagesCountByFilename');
+        $property->setAccessible(true);
+
+        $property->setValue([]);
+    }
+
     /**
      * @dataProvider integrationProvider
      */

--- a/tests/fixtures/expected/blocks/nodes/title.html
+++ b/tests/fixtures/expected/blocks/nodes/title.html
@@ -10,5 +10,8 @@
     <div class="section">
         <h2 id="perevirka-robocogo-seredovisa"><a class="headerlink" href="#perevirka-robocogo-seredovisa" title="Permalink to this headline">Перевірка робочого середовища</a></h2>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <div class="section">
+            <h3 id="checking-your-work-environment-1"><a class="headerlink" href="#checking-your-work-environment-1" title="Permalink to this headline"><code translate="no" class="notranslate">Checking your Work Environment</code></a></h3>
+        </div>
     </div>
 </div>

--- a/tests/fixtures/source/blocks/nodes/title.rst
+++ b/tests/fixtures/source/blocks/nodes/title.rst
@@ -12,3 +12,6 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit.
 -----------------------------
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+
+``Checking your Work Environment``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hello,

This PR try to generate unique link id.

Relative issues in symfony docs:

https://github.com/symfony/symfony-docs/issues/16417
https://github.com/symfony/symfony-docs/issues/16721

rst-parser instantiate NodeRenderer for each node so the only way I found is to use static property and save when id is already rendered on same page.

Examples of changes on symfony-docs:

https://github.com/alamirault/sf-doc-output/commit/45a528110ffd37982b1689b2b622a2a9edb40c9b