### PR TITLE
Add Caddy server config files to the list of known formats

### DIFF
--- a/src/Directive/ConfigurationBlockDirective.php
+++ b/src/Directive/ConfigurationBlockDirective.php
@@ -18,6 +18,7 @@ use function strtoupper;
 class ConfigurationBlockDirective extends SubDirective
 {
     private const LANGUAGE_LABELS = [
+        'caddy' => 'Caddy'
         'env' => 'Bash',
         'html+jinja' => 'Twig',
         'html+php' => 'PHP',


### PR DESCRIPTION
Here: https://github.com/symfony/symfony-docs/pull/18151 we've merged a PR that uses `caddy` as a config format name. So, let's add support for it.