### PR TITLE
Fix language labels array of ConfigurationBlockDirective

### DIFF
--- a/src/Directive/ConfigurationBlockDirective.php
+++ b/src/Directive/ConfigurationBlockDirective.php
@@ -18,7 +18,7 @@ use function strtoupper;
 class ConfigurationBlockDirective extends SubDirective
 {
     private const LANGUAGE_LABELS = [
-        'caddy' => 'Caddy'
+        'caddy' => 'Caddy',
         'env' => 'Bash',
         'html+jinja' => 'Twig',
         'html+php' => 'PHP',


### PR DESCRIPTION
Related to https://github.com/symfony-tools/docs-builder/pull/153 @javiereguiluz 