### PR TITLE
Fix the TOC generation with unique links

### DIFF
--- a/src/DocsKernel.php
+++ b/src/DocsKernel.php
@@ -20,6 +20,7 @@ use Doctrine\RST\Kernel;
 use SymfonyDocsBuilder\Listener\AdmonitionListener;
 use SymfonyDocsBuilder\Listener\AssetsCopyListener;
 use SymfonyDocsBuilder\Listener\CopyImagesListener;
+use SymfonyDocsBuilder\Listener\DuplicatedHeaderIdListener;
 
 class DocsKernel extends Kernel
 {
@@ -48,6 +49,11 @@ class DocsKernel extends Kernel
            PreParseDocumentEvent::PRE_PARSE_DOCUMENT,
            new AdmonitionListener()
        );
+
+        $eventManager->addEventListener(
+            PreParseDocumentEvent::PRE_PARSE_DOCUMENT,
+            new DuplicatedHeaderIdListener()
+        );
 
         $eventManager->addEventListener(
            PreNodeRenderEvent::PRE_NODE_RENDER,

--- a/src/Listener/DuplicatedHeaderIdListener.php
+++ b/src/Listener/DuplicatedHeaderIdListener.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Listener;
+
+use Doctrine\RST\Event\PreParseDocumentEvent;
+use SymfonyDocsBuilder\Renderers\TitleNodeRenderer;
+
+final class DuplicatedHeaderIdListener
+{
+    public function preParseDocument(PreParseDocumentEvent $event): void
+    {
+        // needed because we only need to handle duplicated headers within
+        // the same file, not across all the files being generated
+        TitleNodeRenderer::resetHeaderIdCache();
+    }
+}

--- a/src/Renderers/TitleNodeRenderer.php
+++ b/src/Renderers/TitleNodeRenderer.php
@@ -32,6 +32,11 @@ class TitleNodeRenderer implements NodeRenderer
         $this->templateRenderer = $templateRenderer;
     }
 
+    public static function resetHeaderIdCache(): void
+    {
+        self::$idUsagesCountByFilename = [];
+    }
+
     public function render(): string
     {
         $filename = $this->titleNode->getEnvironment()->getCurrentFileName();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -21,15 +21,6 @@ use SymfonyDocsBuilder\Renderers\TitleNodeRenderer;
 
 class IntegrationTest extends AbstractIntegrationTest
 {
-    public static function setUpBeforeClass(): void
-    {
-        $reflection = new \ReflectionClass(TitleNodeRenderer::class);
-        $property = $reflection->getProperty('idUsagesCountByFilename');
-        $property->setAccessible(true);
-
-        $property->setValue([]);
-    }
-
     /**
      * @dataProvider integrationProvider
      */

--- a/tests/JsonIntegrationTest.php
+++ b/tests/JsonIntegrationTest.php
@@ -10,6 +10,7 @@
 namespace SymfonyDocsBuilder\Tests;
 
 use SymfonyDocsBuilder\DocBuilder;
+use SymfonyDocsBuilder\Renderers\TitleNodeRenderer;
 
 class JsonIntegrationTest extends AbstractIntegrationTest
 {
@@ -26,7 +27,7 @@ class JsonIntegrationTest extends AbstractIntegrationTest
         $actualFileData = $fJsons[$filename];
         foreach ($expectedData as $key => $expectedKeyData) {
             $this->assertArrayHasKey($key, $actualFileData, sprintf('Missing key "%s" in file "%s"', $key, $filename));
-            $this->assertSame($expectedData[$key], $actualFileData[$key], sprintf('Invalid data for key "%s" in file "%s"', $key, $filename));
+            $this->assertSame($expectedKeyData, $actualFileData[$key], sprintf('Invalid data for key "%s" in file "%s"', $key, $filename));
         }
     }
 
@@ -76,8 +77,52 @@ class JsonIntegrationTest extends AbstractIntegrationTest
                 'title' => 'Design',
                 'toc_options' => [
                     'maxDepth' => 2,
-                    'numVisibleItems' => 3,
+                    'numVisibleItems' => 5,
                     'size' => 'md'
+                ],
+                'toc' => [
+                    [
+                        'level' => 1,
+                        'url' => 'design.html#section-1',
+                        'page' => 'design',
+                        'fragment' => 'section-1',
+                        'title' => 'Section 1',
+                        'children' => [
+                            [
+                                'level' => 2,
+                                'url' => 'design.html#some-subsection',
+                                'page' => 'design',
+                                'fragment' => 'some-subsection',
+                                'title' => 'Some subsection',
+                                'children' => [],
+                            ],
+                            [
+                                'level' => 2,
+                                'url' => 'design.html#some-subsection-1',
+                                'page' => 'design',
+                                'fragment' => 'some-subsection-1',
+                                'title' => 'Some subsection',
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                    [
+                        'level' => 1,
+                        'url' => 'design.html#section-2',
+                        'page' => 'design',
+                        'fragment' => 'section-2',
+                        'title' => 'Section 2',
+                        'children' => [
+                            [
+                                'level' => 2,
+                                'url' => 'design.html#some-subsection-2',
+                                'page' => 'design',
+                                'fragment' => 'some-subsection-2',
+                                'title' => 'Some subsection',
+                                'children' => [],
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];

--- a/tests/fixtures/source/json/design.rst
+++ b/tests/fixtures/source/json/design.rst
@@ -11,10 +11,16 @@ The toctree below should affects the next/prev. The
 first entry is effectively ignored, as it was already
 included by the toctree in index.rst (which is parsed first).
 
-Subsection 1
-~~~~~~~~~~~~
+Some subsection
+~~~~~~~~~~~~~~~
 
 This is a subsection of the first section. That's all.
+
+Some subsection
+~~~~~~~~~~~~~~~
+
+This sub-section uses the same title as before to test that the tool
+never generated two or more headings with the same ID.
 
 Section 2
 ---------
@@ -22,6 +28,12 @@ Section 2
 However, crud (which is ALSO included in the toctree in index.rst),
 WILL be read here, as the "crud" in index.rst has not been read
 yet (design comes first). Also, design/sub-page WILL be considered.
+
+Some subsection
+~~~~~~~~~~~~~~~
+
+This sub-section also uses the same title as in the previous section
+to test that the tool never generated two or more headings with the same ID.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Still WIP. It fixes #155.

I can't find any way of getting the `id` attributes of headings without changing the vendor dependencies ... so this proposes to just parse the generated HTML file and extract the information from it.