### PR TITLE
fix: unknown caddy language

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -21,6 +21,7 @@ class CodeNodeRenderer implements NodeRenderer
     private static $isHighlighterConfigured = false;
 
     private const LANGUAGES_MAPPING = [
+        'caddy' => 'plaintext',
         'env' => 'bash',
         'html+jinja' => 'twig',
         'html+twig' => 'twig',


### PR DESCRIPTION
https://github.com/symfony/symfony-docs/commit/83fa5c62a668c5489f2027dd3398072bce0bdedc introduced a new code-block directive 'Caddy'

We have now builds errors like: 
`[ERROR] There were some errors while building the docs:                                                                
         Build errors from "2023-04-25 08:14:03"                                                                        
         Error while processing "code-block" directive: "Unsupported code block language "caddy". Added it in           
         SymfonyDocsBuilder\Renderers\CodeNodeRenderer" in file "security"`

I added 'caddy' as plaintext as there is no definition of caddy's syntax in https://github.com/scrivo/highlight.php