### PR TITLE
Allow using Symfony 7.0 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,18 @@
         "ext-curl": "*",
         "doctrine/rst-parser": "^0.5",
         "scrivo/highlight.php": "^9.18.1",
-        "symfony/filesystem": "^5.2 || ^6.0",
-        "symfony/finder": "^5.2 || ^6.0",
-        "symfony/dom-crawler": "^5.2 || ^6.0",
-        "symfony/css-selector": "^5.2 || ^6.0",
-        "symfony/console": "^5.2 || ^6.0",
-        "symfony/http-client": "^5.2 || ^6.0",
+        "symfony/filesystem": "^5.2 || ^6.0 || ^7.0",
+        "symfony/finder": "^5.2 || ^6.0 || ^7.0",
+        "symfony/dom-crawler": "^5.2 || ^6.0 || ^7.0",
+        "symfony/css-selector": "^5.2 || ^6.0 || ^7.0",
+        "symfony/console": "^5.2 || ^6.0 || ^7.0",
+        "symfony/http-client": "^5.2 || ^6.0 || ^7.0",
         "twig/twig": "^2.14 || ^3.3"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "symfony/phpunit-bridge": "^5.2 || ^6.0",
-        "symfony/process": "^5.2 || ^6.0",
+        "symfony/phpunit-bridge": "^5.2 || ^6.0 || ^7.0",
+        "symfony/process": "^5.2 || ^6.0 || ^7.0",
         "masterminds/html5": "^2.7"
     },
     "bin": ["bin/docs-builder"]


### PR DESCRIPTION
Fixes this problem:

```
 Problem 3
    - Root composer.json requires symfony-tools/docs-builder ^0.21 -> satisfiable by symfony-tools/docs-builder[v0.21.0].
    - symfony-tools/docs-builder v0.21.0 requires symfony/filesystem ^5.2 || ^6.0 -> found symfony/filesystem[v5.2.0-BETA1, ..., v5.4.25, v6.0.0-BETA1, ..., v6.4.0-BETA1] but these were not loaded, likely because it conflicts with another require.
```