### PR TITLE
Add directive test for admonition/danger

### DIFF
--- a/src/Templates/default/html/directives/admonition.html.twig
+++ b/src/Templates/default/html/directives/admonition.html.twig
@@ -5,9 +5,9 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
         {% elseif name in ['hint', 'tip'] %}
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
-        {% elseif name in ['attention', 'important', 'warning'] %}
+        {% elseif name in ['attention', 'caution', 'important', 'warning'] %}
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-        {% elseif name in ['caution', 'danger', 'error'] %}
+        {% elseif name in ['danger', 'error'] %}
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
         {% elseif name in ['versionadded', 'deprecated'] %}
             {# don't show an icon for these directives #}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -158,6 +158,10 @@ class IntegrationTest extends AbstractIntegrationTest
             'blockName' => 'directives/admonition',
         ];
 
+        yield 'danger' => [
+            'blockName' => 'directives/danger',
+        ];
+
         yield 'note-code-block-nested' => [
             'blockName' => 'directives/note-code-block-nested',
         ];

--- a/tests/fixtures/expected/blocks/directives/caution.html
+++ b/tests/fixtures/expected/blocks/directives/caution.html
@@ -1,6 +1,6 @@
 <div class="admonition admonition-caution ">
     <p class="admonition-title">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
         <span>Caution</span>
     </p><p>Using too many sidebars or caution directives can be distracting!</p>
 </div>

--- a/tests/fixtures/expected/blocks/directives/danger.html
+++ b/tests/fixtures/expected/blocks/directives/danger.html
@@ -1,0 +1,6 @@
+<div class="admonition admonition-danger ">
+    <p class="admonition-title">
+       <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                <span>Danger</span>
+    </p><p>This message is about security risk or data integrity threat.</p>
+</div>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -215,9 +215,7 @@ as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/
             </div>
             <div class="admonition admonition-caution ">
                 <p class="admonition-title">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
                     <span>Caution</span>
                 </p>
                 <p>Using too many sidebars or caution directives can be distracting!</p>

--- a/tests/fixtures/source/blocks/directives/danger.rst
+++ b/tests/fixtures/source/blocks/directives/danger.rst
@@ -1,0 +1,4 @@
+
+.. danger::
+
+    This message is about security risk or data integrity threat.


### PR DESCRIPTION
Follows this topic about admonition levels on symfony/symfony-docs: [[RFC] Differenciate "caution" admonitions #19181 ](https://github.com/symfony/symfony-docs/issues/19181)

The bloc `danger` will be used soon in Symfony docs (cc [javiereguiluz](https://github.com/javiereguiluz) [comment](https://github.com/symfony/symfony-docs/issues/19181#issuecomment-1857944528) ).

So this PR allow a single test to check its compilation.