### PR TITLE
Highlight PHP attributes

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -290,6 +290,10 @@ class IntegrationTest extends AbstractIntegrationTest
             'blockName' => 'code-blocks/php-annotations',
         ];
 
+        yield 'code-block-php-attributes' => [
+            'blockName' => 'code-blocks/php-attributes',
+        ];
+
         yield 'code-block-text' => [
             'blockName' => 'code-blocks/text',
         ];

--- a/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
@@ -1,4 +1,4 @@
-<div translate="no" data-loc="45" class="notranslate codeblock codeblock-length-md codeblock-php-attributes codeblock-php">
+<div translate="no" data-loc="48" class="notranslate codeblock codeblock-length-md codeblock-php-attributes codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -44,7 +44,10 @@
 42
 43
 44
-45</pre>
+45
+46
+47
+48</pre>
         <pre class="codeblock-code">
             <code>
                 <span class="hljs-comment">// src/SomePath/SomeClass.php</span>
@@ -130,6 +133,14 @@
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property10</span>
+                ;
+                <span class="hljs-php-attribute">#[ORM\CustomIdGenerator(</span>
+                class:
+                <span class="hljs-string">'doctrine.uuid_generator'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                <span class="hljs-variable-other-marker">$</span> property11</span>
                 ;
 }</code></pre>
     </div>

--- a/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
@@ -1,0 +1,136 @@
+<div translate="no" data-loc="45" class="notranslate codeblock codeblock-length-md codeblock-php-attributes codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45</pre>
+        <pre class="codeblock-code">
+            <code>
+                <span class="hljs-comment">// src/SomePath/SomeClass.php</span>
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">App</span>\<span class="hljs-title">SomePath</span>;
+                <span class="hljs-keyword">use</span><span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Validator</span>\<span class="hljs-title">Constraints</span> <span class="hljs-title">as</span> <span class="hljs-title">Assert</span>;
+                <span class="hljs-class">
+                    <span class="hljs-keyword">class</span>
+                    <span class="hljs-title">SomeClass</span>
+                </span>
+                {
+                <span class="hljs-php-attribute">#[AttributeName]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property1</span>
+                ;
+                <span class="hljs-php-attribute">#[AttributeName(</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property2</span>
+                ;
+                <span class="hljs-php-attribute">#[AttributeName(</span>
+                <span class="hljs-string">'value'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property3</span>
+                ;
+                <span class="hljs-php-attribute">#[AttributeName(</span>
+                <span class="hljs-string">'value'</span>
+                , option:
+                <span class="hljs-string">'value'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property4</span>
+                ;
+                <span class="hljs-php-attribute">#[AttributeName(</span>
+[<span class="hljs-string">'value'</span> =&gt; <span class="hljs-string">'value'</span>]<span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property5</span>
+                ;
+                <span class="hljs-php-attribute">#[AttributeName(</span>
+                <span class="hljs-string">'value'</span>
+                , option:
+                <span class="hljs-string">'value'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property6</span>
+                ;
+                <span class="hljs-php-attribute">#[Assert\AttributeName(</span>
+                <span class="hljs-string">'value'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property7</span>
+                ;
+                <span class="hljs-php-attribute">#[Assert\AttributeName(</span>
+                <span class="hljs-string">'value'</span>
+                , option:
+                <span class="hljs-string">'value'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                    <span class="hljs-variable-other-marker">$</span> property8</span>
+                ;
+                <span class="hljs-php-attribute">#[Route(</span>
+                <span class="hljs-string">'/blog/{page&lt;\d+&gt;}'</span>
+                , name:
+                <span class="hljs-string">'blog_list'</span>
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                <span class="hljs-variable-other-marker">$</span> property9</span>
+                ;
+                <span class="hljs-php-attribute">#[Assert\GreaterThanOrEqual(</span>
+                value:
+                <span class="hljs-number">18</span>
+                ,
+                <span class="hljs-php-attribute">)]</span>
+                <span class="hljs-keyword">private</span>
+                <span class="hljs-variable">
+                <span class="hljs-variable-other-marker">$</span> property10</span>
+                ;
+}</code></pre>
+    </div>
+</div>

--- a/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
+++ b/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
@@ -1,0 +1,48 @@
+.. code-block:: php-attributes
+
+    // src/SomePath/SomeClass.php
+    namespace App\SomePath;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class SomeClass
+    {
+        #[AttributeName]
+        private $property1;
+
+        #[AttributeName()]
+        private $property2;
+
+        #[AttributeName('value')]
+        private $property3;
+
+        #[AttributeName('value', option: 'value')]
+        private $property4;
+
+        #[AttributeName(['value' => 'value'])]
+        private $property5;
+
+        #[AttributeName(
+            'value',
+            option: 'value'
+        )]
+        private $property6;
+
+        #[Assert\AttributeName('value')]
+        private $property7;
+
+         #[Assert\AttributeName(
+            'value',
+            option: 'value'
+         )]
+         private $property8;
+
+         #[Route('/blog/{page<\d+>}', name: 'blog_list')]
+         private $property9;
+
+         #[Assert\GreaterThanOrEqual(
+             value: 18,
+         )]
+         private $property10;
+    }
+

--- a/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
+++ b/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
@@ -31,21 +31,21 @@
         #[Assert\AttributeName('value')]
         private $property7;
 
-         #[Assert\AttributeName(
+        #[Assert\AttributeName(
             'value',
             option: 'value'
-         )]
-         private $property8;
+        )]
+        private $property8;
 
-         #[Route('/blog/{page<\d+>}', name: 'blog_list')]
-         private $property9;
+        #[Route('/blog/{page<\d+>}', name: 'blog_list')]
+        private $property9;
 
-         #[Assert\GreaterThanOrEqual(
-             value: 18,
-         )]
-         private $property10;
+        #[Assert\GreaterThanOrEqual(
+            value: 18,
+        )]
+        private $property10;
 
-         #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-         private $property11;
+        #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+        private $property11;
     }
 

--- a/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
+++ b/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
@@ -44,5 +44,8 @@
              value: 18,
          )]
          private $property10;
+
+         #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+         private $property11;
     }
 


### PR DESCRIPTION
Our current highlighter doesn't support PHP attributes ... but we use more and more attributes in the Symfony Docs.

I tried changing the highlighter (I tested https://github.com/tempestphp/highlight) but, although it solved the attribute issue, they introduced more issues.

So, this PR adds a "hack" to the current highlighter to add support for PHP attributes:

**Before // After**

![](https://github.com/symfony-tools/docs-builder/assets/73419/f23eb39e-fbba-4fc9-a219-08437dfb0bf7)

-----

I added many tests to ensure that we support all the different ways of defining PHP attributes. There's still an edge case related to multi-line attributes. It's not a big problem and I'll tackle this in a future PR.