### PR TITLE
Fixes for PHP attribute parsing

### DIFF
--- a/src/Templates/highlight.php/php.json
+++ b/src/Templates/highlight.php/php.json
@@ -11,17 +11,30 @@
     "keywords": "and include_once list abstract global private echo interface as static endswitch array null if endwhile or const for endforeach self var while isset public protected exit foreach throw elseif include __FILE__ empty require_once do xor return parent clone use __CLASS__ __LINE__ else break print eval new catch __METHOD__ case exception default die require __FUNCTION__ enddeclare final try match switch continue endfor endif declare unset true false goto instanceof insteadof __DIR__ __NAMESPACE__ yield finally",
     "contains": [
         {
-            "className": "php-attribute",
-            "begin": "#\\[\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+|\\\\?[A-Z]+(?=[A-Z][a-z0-9_\\x7f-\\xff])){1,}(?![A-Za-z0-9])(?![$])",
+            "className": "meta",
+            "begin": "#\\[\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+\\]"
+        },
+        {
+            "begin": "#\\[\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+(?![A-Za-z0-9])(?![$])",
             "end": "]",
+            "returnBegin": true,
             "contains": [
+                {
+                    "className": "meta",
+                    "begin": "#\\[\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+(?![A-Za-z0-9])(?![$])"
+                },
                 {
                     "begin": "\\(",
                     "end": "\\)",
                     "keywords": "true false null new array",
                     "contains": {
-                        "$ref": "#contains.10.contains.1.contains"
+                        "$ref": "#contains.11.contains.1.contains"
                     }
+                },
+                {
+                    "className": "meta",
+                    "begin": "]",
+                    "endsParent": true
                 }
             ]
         },
@@ -50,7 +63,7 @@
                     "begin": "<\\?(php)?|\\?>"
                 },
                 {
-                    "$ref": "#contains.1.contains.0"
+                    "$ref": "#contains.2.contains.0"
                 },
                 {
                     "className": "doctag",
@@ -69,7 +82,7 @@
                     "begin": "@[A-Za-z]+"
                 },
                 {
-                    "$ref": "#contains.1.contains.0"
+                    "$ref": "#contains.2.contains.0"
                 },
                 {
                     "className": "doctag",
@@ -84,7 +97,7 @@
             "end": false,
             "contains": [
                 {
-                    "$ref": "#contains.1.contains.0"
+                    "$ref": "#contains.2.contains.0"
                 },
                 {
                     "className": "doctag",
@@ -120,7 +133,7 @@
             ]
         },
         {
-            "$ref": "#contains.2.contains.0"
+            "$ref": "#contains.3.contains.0"
         },
         {
             "className": "variable",
@@ -156,7 +169,7 @@
                     "contains": [
                         "self",
                         {
-                            "$ref": "#contains.8"
+                            "$ref": "#contains.9"
                         },
                         {
                             "className": "comment",
@@ -164,7 +177,7 @@
                             "end": "\\*/",
                             "contains": [
                                 {
-                                    "$ref": "#contains.1.contains.0"
+                                    "$ref": "#contains.2.contains.0"
                                 },
                                 {
                                     "className": "doctag",
@@ -177,10 +190,10 @@
                             "className": "string",
                             "contains": [
                                 {
-                                    "$ref": "#contains.5.contains.0"
+                                    "$ref": "#contains.6.contains.0"
                                 },
                                 {
-                                    "$ref": "#contains.2.contains.0"
+                                    "$ref": "#contains.3.contains.0"
                                 }
                             ],
                             "variants": [
@@ -199,7 +212,7 @@
                                     "illegal": null,
                                     "contains": [
                                         {
-                                            "$ref": "#contains.5.contains.0"
+                                            "$ref": "#contains.6.contains.0"
                                         }
                                     ]
                                 },
@@ -210,7 +223,7 @@
                                     "illegal": null,
                                     "contains": [
                                         {
-                                            "$ref": "#contains.5.contains.0"
+                                            "$ref": "#contains.6.contains.0"
                                         },
                                         {
                                             "className": "subst",
@@ -239,6 +252,12 @@
                                     "relevance": 0
                                 }
                             ]
+                        },
+                        {
+                            "$ref": "#contains.0"
+                        },
+                        {
+                            "$ref": "#contains.1"
                         }
                     ]
                 }
@@ -255,7 +274,7 @@
                     "beginKeywords": "extends implements"
                 },
                 {
-                    "$ref": "#contains.10.contains.0"
+                    "$ref": "#contains.11.contains.0"
                 }
             ]
         },
@@ -265,7 +284,7 @@
             "illegal": "[\\.']",
             "contains": [
                 {
-                    "$ref": "#contains.10.contains.0"
+                    "$ref": "#contains.11.contains.0"
                 }
             ]
         },
@@ -274,7 +293,7 @@
             "end": ";",
             "contains": [
                 {
-                    "$ref": "#contains.10.contains.0"
+                    "$ref": "#contains.11.contains.0"
                 }
             ]
         },
@@ -282,10 +301,10 @@
             "begin": "=>"
         },
         {
-            "$ref": "#contains.10.contains.1.contains.3"
+            "$ref": "#contains.11.contains.1.contains.3"
         },
         {
-            "$ref": "#contains.10.contains.1.contains.4"
+            "$ref": "#contains.11.contains.1.contains.4"
         }
     ]
 }

--- a/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
@@ -1,4 +1,4 @@
-<div translate="no" data-loc="54" class="notranslate codeblock codeblock-length-md codeblock-php-attributes codeblock-php">
+<div translate="no" data-loc="65" class="notranslate codeblock codeblock-length-md codeblock-php-attributes codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -53,7 +53,18 @@
 51
 52
 53
-54</pre>
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65</pre>
         <pre class="codeblock-code">
             <code>
                 <span class="hljs-comment">// src/SomePath/SomeClass.php</span>
@@ -64,77 +75,87 @@
                     <span class="hljs-title">SomeClass</span>
                 </span>
                 {
-                <span class="hljs-php-attribute">#[AttributeName]</span>
+                <span class="hljs-meta">#[AttributeName]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property1</span>
                 ;
-                <span class="hljs-php-attribute">#[AttributeName()]</span>
+                <span class="hljs-meta">#[AttributeName</span>()<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property2</span>
                 ;
-                <span class="hljs-php-attribute">#[AttributeName(<span class="hljs-string">'value'</span>)]</span>
+                <span class="hljs-meta">#[AttributeName</span>(<span class="hljs-string">'value'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property3</span>
                 ;
-                <span class="hljs-php-attribute">#[AttributeName(<span class="hljs-string">'value'</span>, option: <span class="hljs-string">'value'</span>)]</span>
+                <span class="hljs-meta">#[AttributeName</span>(<span class="hljs-string">'value'</span>, option: <span class="hljs-string">'value'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property4</span>
                 ;
-                <span class="hljs-php-attribute">#[AttributeName([<span class="hljs-string">'value'</span> =&gt; <span class="hljs-string">'value'</span>])]</span>
+                <span class="hljs-meta">#[AttributeName</span>([<span class="hljs-string">'value'</span> =&gt; <span class="hljs-string">'value'</span>])<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property5</span>
                 ;
-                <span class="hljs-php-attribute">#[AttributeName(
+                <span class="hljs-meta">#[AttributeName</span>(
                     <span class="hljs-string">'value'</span>,
                     option: <span class="hljs-string">'value'</span>
-                )]</span>
+                )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property6</span>
                 ;
-                <span class="hljs-php-attribute">#[Assert\AttributeName(<span class="hljs-string">'value'</span>)]</span>
+                <span class="hljs-meta">#[Assert\AttributeName</span>(<span class="hljs-string">'value'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property7</span>
                 ;
-                <span class="hljs-php-attribute">#[Assert\AttributeName(
+                <span class="hljs-meta">#[Assert\AttributeName</span>(
                     <span class="hljs-string">'value'</span>,
                     option: <span class="hljs-string">'value'</span>
-                )]</span>
+                )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property8</span>
                 ;
-                <span class="hljs-php-attribute">#[Route(<span class="hljs-string">'/blog/{page&lt;\d+&gt;}'</span>, name: <span class="hljs-string">'blog_list'</span>)]</span>
+                <span class="hljs-meta">#[Route</span>(<span class="hljs-string">'/blog/{page&lt;\d+&gt;}'</span>, name: <span class="hljs-string">'blog_list'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property9</span>
                 ;
-                <span class="hljs-php-attribute">#[Assert\GreaterThanOrEqual(
+                <span class="hljs-meta">#[Assert\GreaterThanOrEqual</span>(
                     value: <span class="hljs-number">18</span>,
-                )]</span>
+                )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property10</span>
                 ;
-                <span class="hljs-php-attribute">#[ORM\CustomIdGenerator(class: <span class="hljs-string">'doctrine.uuid_generator'</span>)]</span>
+                <span class="hljs-meta">#[ORM\CustomIdGenerator</span>(class: <span class="hljs-string">'doctrine.uuid_generator'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property11</span>
                 ;
-                <span class="hljs-php-attribute">#[Assert\AtLeastOneOf([
+                <span class="hljs-meta">#[Assert\AtLeastOneOf</span>([
                     <span class="hljs-keyword">new</span> Assert\Regex(<span class="hljs-string">'/#/'</span>),
                     <span class="hljs-keyword">new</span> Assert\Length(min: <span class="hljs-number">10</span>),
-                ])]</span>
+                ])<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property12</span>
                 ;
+                <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">__construct</span><span class="hljs-params">(
+                        <span class="hljs-meta">#[TaggedIterator</span>(<span class="hljs-string">'app.handlers'</span>)<span class="hljs-meta">]</span>
+                        iterable <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>handlers</span>,
+                )</span></span>{
+                }
+
+                <span class="hljs-meta">#[AsController]</span>
+                <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-title">someAction</span><span class="hljs-params">(<span class="hljs-meta">#[CurrentUser]</span> User <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>user</span>)</span></span>
+                {
+                }
 }</code></pre>
     </div>
 </div>

--- a/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
+++ b/tests/fixtures/source/blocks/code-blocks/php-attributes.rst
@@ -53,4 +53,15 @@
             new Assert\Length(min: 10),
         ])]
         private $property12;
+
+        public function __construct(
+            #[TaggedIterator('app.handlers')]
+            iterable $handlers,
+        ) {
+        }
+
+        #[AsController]
+        public function someAction(#[CurrentUser] User $user)
+        {
+        }
     }


### PR DESCRIPTION
- No longer wrap the entire attribute in a span, but only wrap `#[Route` and `]` in spans (fixes #174)
- @javiereguiluz for consistency with the real PHP highlight.js file, I've renamed `php-attributes` to `meta`. Is it OK for you to update the CSS on symfony.com to style `.hljs-meta` instead of `.hljs-php-attributes`?
- Fixed not parsing attributes in parameters, see e.g. https://symfony.com/doc/current/controller.html#mapping-the-whole-query-string