### PR TITLE
Fix attribute arguments highlighting and better support CPP

### DIFF
--- a/src/Templates/highlight.php/php.json
+++ b/src/Templates/highlight.php/php.json
@@ -28,7 +28,7 @@
                     "end": "\\)",
                     "keywords": "array bool boolean float int integer new real string false FALSE null NULL true TRUE PHP_VERSION PHP_MAJOR_VERSION PHP_MINOR_VERSION PHP_RELEASE_VERSION PHP_VERSION_ID PHP_EXTRA_VERSION ZEND_THREAD_SAFE ZEND_DEBUG_BUILD PHP_ZTS PHP_DEBUG PHP_MAXPATHLEN PHP_OS PHP_OS_FAMILY PHP_SAPI PHP_EOL PHP_INT_MAX PHP_INT_MIN PHP_INT_SIZE PHP_FLOAT_DIG PHP_FLOAT_EPSILON PHP_FLOAT_MIN PHP_FLOAT_MAX DEFAULT_INCLUDE_PATH PEAR_INSTALL_DIR PEAR_EXTENSION_DIR PHP_EXTENSION_DIR PHP_PREFIX PHP_BINDIR PHP_BINARY PHP_MANDIR PHP_LIBDIR PHP_DATADIR PHP_SYSCONFDIR PHP_LOCALSTATEDIR PHP_CONFIG_FILE_PATH PHP_CONFIG_FILE_SCAN_DIR PHP_SHLIB_SUFFIX PHP_FD_SETSIZE E_ERROR E_WARNING E_PARSE E_NOTICE E_CORE_ERROR E_CORE_WARNING E_COMPILE_ERROR E_COMPILE_WARNING E_USER_ERROR E_USER_WARNING E_USER_NOTICE E_RECOVERABLE_ERROR E_DEPRECATED E_USER_DEPRECATED E_ALL E_STRICT __COMPILER_HALT_OFFSET__ PHP_WINDOWS_EVENT_CTRL_C PHP_WINDOWS_EVENT_CTRL_BREAK PHP_CLI_PROCESS_TITLE STDERR STDIN STDOUT __CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__",
                     "contains": {
-                        "$ref": "#contains.10.contains.3.contains",
+                        "$ref": "#contains.9.contains.1.contains",
                         "_": "params"
                     }
                 },
@@ -250,7 +250,7 @@
                     "className": "params",
                     "begin": "\\(",
                     "end": "\\)",
-                    "keywords": "array bool boolean callable float int integer iterable mixed never numeric object real string resource self static false FALSE null NULL true TRUE",
+                    "keywords": "array bool boolean callable float int integer iterable mixed never numeric object private protected public real string resource self static false FALSE null NULL true TRUE",
                     "contains": [
                         "self",
                         {

--- a/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-attributes.html
@@ -90,7 +90,7 @@
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property3</span>
                 ;
-                <span class="hljs-meta">#[AttributeName</span>(<span class="hljs-string">'value'</span>, option: <span class="hljs-string">'value'</span>)<span class="hljs-meta">]</span>
+                <span class="hljs-meta">#[AttributeName</span>(<span class="hljs-string">'value'</span>, <span class="hljs-attr">option</span>: <span class="hljs-string">'value'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property4</span>
@@ -102,7 +102,7 @@
                 ;
                 <span class="hljs-meta">#[AttributeName</span>(
                     <span class="hljs-string">'value'</span>,
-                    option: <span class="hljs-string">'value'</span>
+                    <span class="hljs-attr">option</span>: <span class="hljs-string">'value'</span>
                 )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
@@ -115,32 +115,32 @@
                 ;
                 <span class="hljs-meta">#[Assert\AttributeName</span>(
                     <span class="hljs-string">'value'</span>,
-                    option: <span class="hljs-string">'value'</span>
+                    <span class="hljs-attr">option</span>: <span class="hljs-string">'value'</span>
                 )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                     <span class="hljs-variable-other-marker">$</span> property8</span>
                 ;
-                <span class="hljs-meta">#[Route</span>(<span class="hljs-string">'/blog/{page&lt;\d+&gt;}'</span>, name: <span class="hljs-string">'blog_list'</span>)<span class="hljs-meta">]</span>
+                <span class="hljs-meta">#[Route</span>(<span class="hljs-string">'/blog/{page&lt;\d+&gt;}'</span>, <span class="hljs-attr">name</span>: <span class="hljs-string">'blog_list'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property9</span>
                 ;
                 <span class="hljs-meta">#[Assert\GreaterThanOrEqual</span>(
-                    value: <span class="hljs-number">18</span>,
+                    <span class="hljs-attr">value</span>: <span class="hljs-number">18</span>,
                 )<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property10</span>
                 ;
-                <span class="hljs-meta">#[ORM\CustomIdGenerator</span>(class: <span class="hljs-string">'doctrine.uuid_generator'</span>)<span class="hljs-meta">]</span>
+                <span class="hljs-meta">#[ORM\CustomIdGenerator</span>(<span class="hljs-attr">class</span>: <span class="hljs-string">'doctrine.uuid_generator'</span>)<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">
                 <span class="hljs-variable-other-marker">$</span> property11</span>
                 ;
                 <span class="hljs-meta">#[Assert\AtLeastOneOf</span>([
-                    <span class="hljs-keyword">new</span> Assert\Regex(<span class="hljs-string">'/#/'</span>),
-                    <span class="hljs-keyword">new</span> Assert\Length(min: <span class="hljs-number">10</span>),
+                    <span class="hljs-keyword">new</span> Assert\<span class="hljs-title invoke__">Regex</span>(<span class="hljs-string">'/#/'</span>),
+                    <span class="hljs-keyword">new</span> Assert\<span class="hljs-title invoke__">Length</span>(<span class="hljs-attr">min</span>: <span class="hljs-number">10</span>),
                 ])<span class="hljs-meta">]</span>
                 <span class="hljs-keyword">private</span>
                 <span class="hljs-variable">

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -97,3 +97,17 @@
         </code></pre>
     </div>
 </div>
+<div translate="no" data-loc="4" class="notranslate codeblock codeblock-length-sm codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4</pre>
+        <pre class="codeblock-code"><code>
+<span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">__construct</span><span class="hljs-params">(
+    <span class="hljs-keyword">private</span> <span class="hljs-keyword">string</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>username</span>
+)</span></span> {
+}
+        </code></pre>
+    </div>
+</div>

--- a/tests/fixtures/source/blocks/code-blocks/php.rst
+++ b/tests/fixtures/source/blocks/code-blocks/php.rst
@@ -47,3 +47,10 @@
             $this->loadUser(...)
         );
     }
+
+.. code-block:: php
+
+    public function __construct(
+        private string $username
+    ) {
+    }


### PR DESCRIPTION
@javiereguiluz after seeing my changes online, I discovered 2 minor bugs that are fixed with this PR:
- Highlight `public`/`protected`/`private` when using constructor property promotion
- Fix highlighting attribute arguments (these were now parsed as function definition parameters instead of invocation arguments, e.g. lacking named argument support)