### PR TITLE
Add support for tilde characters

### DIFF
--- a/src/Renderers/SpanNodeRenderer.php
+++ b/src/Renderers/SpanNodeRenderer.php
@@ -42,6 +42,19 @@ class SpanNodeRenderer extends AbstractSpanNodeRenderer
         $this->symfonyVersion = $symfonyVersion;
     }
 
+    public function render(): string
+    {
+        // Work around "~" being parsed as non-breaking space by rst-parser,
+        // while this is not part of the specification.
+        $spanValue = $this->span->getValue();
+        $spanValue = str_replace('~', '__TILDE__', $spanValue);
+        $this->span->setValue($spanValue);
+
+        $rendered = parent::render();
+
+        return str_replace('__TILDE__', '~', $rendered);
+    }
+
     /** @inheritDoc */
     public function link(?string $url, string $title, array $attributes = []): string
     {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -142,6 +142,10 @@ class IntegrationTest extends AbstractIntegrationTest
             'blockName' => 'nodes/span-link',
         ];
 
+        yield 'text' => [
+            'blockName' => 'nodes/text',
+        ];
+
         yield 'title' => [
             'blockName' => 'nodes/title',
         ];

--- a/tests/fixtures/expected/blocks/nodes/text.html
+++ b/tests/fixtures/expected/blocks/nodes/text.html
@@ -1,0 +1,7 @@
+<p><strong>Lorem ipsum</strong> dolor sit amet, consectetur adipisicing elit. Ut enim ad minim
+veniam, quis nostrud <em>exercitation ullamco laboris</em> nisi ut aliquip ex ea
+commodo consequat. <code translate="no" class="notranslate">Duis aute irure dolor</code> in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur.</p>
+
+<p>Excepteur ~1,000 sint! Occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. áàâäãåéèêëíìîïóòôöõúùûüñçÿ</p>

--- a/tests/fixtures/source/blocks/nodes/text.rst
+++ b/tests/fixtures/source/blocks/nodes/text.rst
@@ -1,0 +1,7 @@
+**Lorem ipsum** dolor sit amet, consectetur adipisicing elit. Ut enim ad minim
+veniam, quis nostrud *exercitation ullamco laboris* nisi ut aliquip ex ea
+commodo consequat. ``Duis aute irure dolor`` in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur.
+
+Excepteur ~1,000 sint! Occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. áàâäãåéèêëíìîïóòôöõúùûüñçÿ


### PR DESCRIPTION
Related to
* https://github.com/symfony/symfony-docs/issues/20215

This PR adds a failing test that shows the issue. This is the output change that would make test pass:

```diff
-<p>Excepteur &nbsp;1,000 sint! ...
+<p>Excepteur ~1,000 sint! ...
```