### PR TITLE
Don't use the deprecated spaceless filter

### DIFF
--- a/src/Templates/default/html/figure.html.twig
+++ b/src/Templates/default/html/figure.html.twig
@@ -1,12 +1,7 @@
 {#
 Overridden to fix lack of figclass support (class attribute on <figure)
 #}
-{% apply spaceless %}
-<figure
-    {% if figureNode.classes is not empty %}
-    class="{{ figureNode.classesString }}"
-    {% endif %}
->
+<figure {% if figureNode.classes is not empty %}class="{{ figureNode.classesString }}"{% endif %}>
     {{ figureNode.image.render()|raw }}
 
     {% if figureNode.document %}
@@ -17,4 +12,3 @@ Overridden to fix lack of figclass support (class attribute on <figure)
         {% endif %}
     {% endif %}
 </figure>
-{% endapply %}

--- a/src/Templates/default/html/link.html.twig
+++ b/src/Templates/default/html/link.html.twig
@@ -1,5 +1,3 @@
-{% apply spaceless %}
 {% set domElement = attributes.domElement|default %}
 {% set class = (attributes.class|default ? attributes.class ~ ' ' : '') ~ 'reference ' ~ (('://' in url) ? 'external' : 'internal') %}
 <a href="{{ url|raw }}" class="{{ class }}"{% for key, value in attributes|filter((v, key) => key != 'domElement' and key != 'class') %} {{ key }}="{{ value }}"{% endfor %}>{% if domElement %}<{{ domElement }}>{% endif %}{{ title|raw }}{% if domElement %}</{{ domElement }}>{% endif %}</a>
-{% endapply %}

--- a/src/Templates/default/html/toc-level.html.twig
+++ b/src/Templates/default/html/toc-level.html.twig
@@ -1,7 +1,5 @@
-{% apply spaceless %}
-    <ul class="toctree toctree-level-{{ toc_deep_level ?? 1 }} toctree-length-{{ tocItems|length }}">
-        {% for tocItem in tocItems %}
-            {% include "toc-item.html.twig" with { toc_deep_level: 1 } %}
-        {% endfor %}
-    </ul>
-{% endapply %}
+<ul class="toctree toctree-level-{{ toc_deep_level ?? 1 }} toctree-length-{{ tocItems|length }}">
+    {% for tocItem in tocItems %}
+        {% include "toc-item.html.twig" with { toc_deep_level: 1 } %}
+    {% endfor %}
+</ul>

--- a/src/Templates/default/html/toc.html.twig
+++ b/src/Templates/default/html/toc.html.twig
@@ -1,6 +1,4 @@
-{% apply spaceless %}
-    {% set toc_options = toc_options(tocItems) %}
-    <div class="toctree-wrapper toc-size-{{ toc_options.size }}">
-        {% include "toc-level.html.twig" %}
-    </div>
-{% endapply %}
+{% set toc_options = toc_options(tocItems) %}
+<div class="toctree-wrapper toc-size-{{ toc_options.size }}">
+    {% include "toc-level.html.twig" %}
+</div>

--- a/tests/fixtures/expected/build-pdf/book.html
+++ b/tests/fixtures/expected/build-pdf/book.html
@@ -8,8 +8,8 @@
         <p>Here is a link to the <a href="#index" class="reference internal">main index</a></p>
         <div class="toctree-wrapper toc-size-md">
             <ul class="toctree toctree-level-1 toctree-length-2">
-                <li><a href="https://symfony.com/doc/4.0/book/first-page.html">First page</a></li>
-                <li><a href="https://symfony.com/doc/4.0/book/second-page.html">Second page</a></li>
+                <li> <a href="https://symfony.com/doc/4.0/book/first-page.html">First page</a> </li>
+                <li> <a href="https://symfony.com/doc/4.0/book/second-page.html">Second page</a> </li>
             </ul>
         </div>
     </div>

--- a/tests/fixtures/expected/main/index.html
+++ b/tests/fixtures/expected/main/index.html
@@ -10,7 +10,7 @@
             <div class="section">
 <h1 id="some-test-docs"><a class="headerlink" href="#some-test-docs" title="Permalink to this headline">Some Test Docs!</a></h1>
 <img src="_images/symfony-logo.png" />
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li><a href="datetime.html">DateTimeType Field</a><ul class="toctree toctree-level-2 toctree-length-4"><li><a href="datetime.html#field-options">Field Options</a></li><li><a href="datetime.html#overridden-options">Overridden Options</a></li><li><a href="datetime.html#field-variables">Field Variables</a></li><li><a href="datetime.html#url-checker-errors">Url checker errors</a></li></ul></li><li><a href="form/form_type.html">FormType Documentation</a></li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li><a href="datetime.html">DateTimeType Field</a><ul class="toctree toctree-level-2 toctree-length-4"><li> <a href="datetime.html#field-options">Field Options</a> </li><li> <a href="datetime.html#overridden-options">Overridden Options</a> </li><li> <a href="datetime.html#field-variables">Field Variables</a> </li><li> <a href="datetime.html#url-checker-errors">Url checker errors</a> </li></ul></li><li> <a href="form/form_type.html">FormType Documentation</a> </li></ul></div>
 <span id="reference-forms-type-date-format"></span>
 <div class="section">
 <h2 id="a-header"><a class="headerlink" href="#a-header" title="Permalink to this headline">A header</a></h2>

--- a/tests/fixtures/expected/toctree/index.html
+++ b/tests/fixtures/expected/toctree/index.html
@@ -9,11 +9,11 @@
     <body>
             <div class="section">
 <h1 id="toctree"><a class="headerlink" href="#toctree" title="Permalink to this headline">Toctree</a></h1>
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li></ul></div>
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html">Title</a></li></ul></div>
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="directory/another_file.html">Another file</a></li></ul></div>
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li><a href="directory/another_file.html">Another file</a></li><li><a href="file.html">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li></ul></div>
-<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li><a href="file.html">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="directory/another_file.html">Another file</a></li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li> <a href="file.html#sub-title">Sub title</a> </li></ul></li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li> <a href="file.html">Title</a> </li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-1"><li> <a href="directory/another_file.html">Another file</a> </li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li> <a href="directory/another_file.html">Another file</a> </li><li><a href="file.html">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li> <a href="file.html#sub-title">Sub title</a> </li></ul></li></ul></div>
+<div class="toctree-wrapper toc-size-md"><ul class="toctree toctree-level-1 toctree-length-2"><li> <a href="file.html">Title</a> <ul class="toctree toctree-level-2 toctree-length-1"><li> <a href="file.html#sub-title">Sub title</a> </li></ul></li><li> <a href="directory/another_file.html">Another file</a> </li></ul></div>
 
 </div>
 


### PR DESCRIPTION
This fixes the following deprecations that are making CI to fail:

```
Remaining indirect deprecation notices (3)

  1x: Since twig/twig 3.12: Twig Filter "spaceless" is deprecated in /home/runner/work/docs-builder/docs-builder/src/Templates/default/html/toc.html.twig at line 1.
    1x in BuildDocsCommandTest::testBuildDocsDefault from App\Tests\Command

  1x: Since twig/twig 3.12: Twig Filter "spaceless" is deprecated in /home/runner/work/docs-builder/docs-builder/src/Templates/default/html/link.html.twig at line 1.
    1x in BuildDocsCommandTest::testBuildDocsDefault from App\Tests\Command

  1x: Since twig/twig 3.12: Twig Filter "spaceless" is deprecated in /home/runner/work/docs-builder/docs-builder/src/Templates/default/html/figure.html.twig at line 4.
    1x in IntegrationTest::testParseUnitBlock from SymfonyDocsBuilder\Tests
```