### PR TITLE
Add support for inline Twig comments

### DIFF
--- a/src/Templates/highlight.php/twig.json
+++ b/src/Templates/highlight.php/twig.json
@@ -26,12 +26,21 @@
             "end": "%}",
             "contains": [
                 {
+                    "className": "comment",
+                    "begin": "#",
+                    "end": "$",
+                    "endsWithParent": true
+                },
+                {
                     "className": "name",
                     "begin": "\\w+",
                     "keywords": "apply autoescape block deprecated do embed extends filter flush for from if import include macro sandbox set use verbatim with endapply endautoescape endblock enddeprecated enddo endembed endextends endfilter endflush endfor endfrom endif endimport endinclude endmacro endsandbox endset enduse endverbatim endwith",
                     "starts": {
                         "endsWithParent": true,
                         "contains": [
+                            {
+                                "$ref": "#contains.1.contains.0"
+                            },
                             {
                                 "begin": "\\|[A-Za-z_]+:?",
                                 "keywords": "abs batch capitalize column convert_encoding date date_modify default escape filter first format inky_to_html inline_css join json_encode keys last length lower map markdown merge nl2br number_format raw reduce replace reverse round slice sort spaceless split striptags title trim upper url_encode",
@@ -53,7 +62,7 @@
                                 ]
                             },
                             {
-                                "$ref": "#contains.1.contains.0.starts.contains.0.contains.0"
+                                "$ref": "#contains.1.contains.1.starts.contains.1.contains.0"
                             }
                         ],
                         "relevance": 0
@@ -68,10 +77,13 @@
             "contains": [
                 "self",
                 {
-                    "$ref": "#contains.1.contains.0.starts.contains.0"
+                    "$ref": "#contains.1.contains.0"
                 },
                 {
-                    "$ref": "#contains.1.contains.0.starts.contains.0.contains.0"
+                    "$ref": "#contains.1.contains.1.starts.contains.1"
+                },
+                {
+                    "$ref": "#contains.1.contains.1.starts.contains.1.contains.0"
                 }
             ]
         }

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -1,6 +1,30 @@
-<div translate="no" data-loc="1" class="notranslate codeblock codeblock-length-sm codeblock-twig">
+<div translate="no" data-loc="9" class="notranslate codeblock codeblock-length-sm codeblock-twig">
     <div class="codeblock-scroll">
-        <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span></code></pre>
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9</pre>
+        <pre class="codeblock-code">
+            <code>
+                <span class="hljs-comment">{# some code #}</span>
+                <span class="xml"></span>
+                <span class="hljs-template-tag">
+                    {%
+                        <span class="hljs-name"><span class="hljs-keyword">set</span></span> some_var = 'some value' <span class="hljs-comment"># some inline comment</span>
+                    %}
+                </span>
+                <span class="xml"></span>
+                <span class="hljs-template-variable">{{
+                    <span class="hljs-comment"># another inline comment</span>
+                    'Lorem Ipsum'|uppercase
+                    <span class="hljs-comment"># final inline comment</span>
+                }}</span>
+            </code>
+        </pre>
     </div>
 </div>

--- a/tests/fixtures/source/blocks/code-blocks/twig.rst
+++ b/tests/fixtures/source/blocks/code-blocks/twig.rst
@@ -1,3 +1,11 @@
-
 .. code-block:: twig
+
     {# some code #}
+    {%
+        set some_var = 'some value' # some inline comment
+    %}
+    {{
+        # another inline comment
+        'Lorem Ipsum'|uppercase
+        # final inline comment
+    }}


### PR DESCRIPTION
Twig added inline comments (https://github.com/twigphp/Twig/pull/4349) so I tried to add support for them here. But, it's not working. Anyone knows if this could be easy to fix or if it's too complex to do it? Thanks!