### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Renderers/SpanNodeRenderer.php
+++ b/src/Renderers/SpanNodeRenderer.php
@@ -32,7 +32,7 @@ class SpanNodeRenderer extends AbstractSpanNodeRenderer
         SpanNode $span,
         BaseSpanNodeRenderer $decoratedSpanNodeRenderer,
         ?UrlChecker $urlChecker = null,
-        string $symfonyVersion = null
+        ?string $symfonyVersion = null
     )
     {
         parent::__construct($environment, $span);

--- a/src/SymfonyHTMLFormat.php
+++ b/src/SymfonyHTMLFormat.php
@@ -29,7 +29,7 @@ final class SymfonyHTMLFormat implements Format
     private $urlChecker;
     private $symfonyVersion;
 
-    public function __construct(TemplateRenderer $templateRenderer, Format $HTMLFormat, ?UrlChecker $urlChecker = null, string $symfonyVersion = null)
+    public function __construct(TemplateRenderer $templateRenderer, Format $HTMLFormat, ?UrlChecker $urlChecker = null, ?string $symfonyVersion = null)
     {
         $this->templateRenderer = $templateRenderer;
         $this->htmlFormat = $HTMLFormat;


### PR DESCRIPTION
It fixes this:

```
SymfonyDocsBuilder\SymfonyHTMLFormat::__construct(): Implicitly marking parameter
$symfonyVersion as nullable is deprecated, the explicit nullable type must be used instead

SymfonyDocsBuilder\Renderers\SpanNodeRenderer::__construct(): Implicitly marking parameter 
$symfonyVersion as nullable is deprecated, the explicit nullable type must be used instead
```