### PR TITLE
Fix a Twig deprecation

### DIFF
--- a/src/Templates/default/html/image.html.twig
+++ b/src/Templates/default/html/image.html.twig
@@ -2,7 +2,7 @@
     Overridden so we can control the path to the image based on our copying logic.
     See CopyImagesListener.
 #}
-{% set wrap_image_with_browser = 'with-browser' in imageNode.options.class ?? '' %}
+{% set wrap_image_with_browser = 'with-browser' in (imageNode.options.class ?? '') %}
 {% if wrap_image_with_browser %}<div class="with-browser">{% endif %}
 <img src="{{ imageNode.value }}" {% for key, value in imageNode.options %}{{ key }}="{{ value }}" {% endfor %}/>
 {% if wrap_image_with_browser %}</div>{% endif %}


### PR DESCRIPTION
Fixes this:

Since twig/twig 3.15: Add explicit parentheses around the "??" binary operator to avoid behavior change in the next major version as its precedence will change in "image.html.twig" at line 5.