### PR TITLE
Add support for phpclass reference with namespace

### DIFF
--- a/src/Reference/PhpClassReference.php
+++ b/src/Reference/PhpClassReference.php
@@ -29,10 +29,11 @@ class PhpClassReference extends Reference
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
+        $classnamePath = str_replace('\\', '-', strtolower($data));
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $data,
-            sprintf('%s/class.%s.php', $this->phpDocUrl, strtolower($data)),
+            sprintf('%s/class.%s.php', $this->phpDocUrl, $classnamePath),
             [],
             [
                 'title' => $data,

--- a/tests/fixtures/expected/blocks/references/php-class.html
+++ b/tests/fixtures/expected/blocks/references/php-class.html
@@ -1,1 +1,2 @@
 <p><a href="https://secure.php.net/manual/en/class.arrayaccess.php" class="reference external" title="ArrayAccess" rel="external noopener noreferrer" target="_blank">ArrayAccess</a></p>
+<p><a href="https://secure.php.net/manual/en/class.bcmath-number.php" class="reference external" title="BcMath\Number" rel="external noopener noreferrer" target="_blank">BcMath\Number</a></p>

--- a/tests/fixtures/source/blocks/references/php-class.rst
+++ b/tests/fixtures/source/blocks/references/php-class.rst
@@ -1,2 +1,4 @@
 
 :phpclass:`ArrayAccess`
+
+:phpclass:`BcMath\Number`


### PR DESCRIPTION
PHP have now classes with namespaces but it not supported by `:phpclass:` reference yet

https://www.php.net/manual/en/class.bcmath-number.php