### PR TITLE
Make behavior of PHP and GitHub references consistent

### DIFF
--- a/src/Reference/MethodReference.php
+++ b/src/Reference/MethodReference.php
@@ -30,20 +30,19 @@ class MethodReference extends Reference
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
-        $className = explode('::', $data)[0];
-        $className = str_replace('\\\\', '\\', $className);
-
-        if (!u($data)->containsAny('::')) {
+        $data = u($data);
+        if (!$data->containsAny('::')) {
             throw new \RuntimeException(sprintf('Malformed method reference "%s" in file "%s"', $data, $environment->getCurrentFileName()));
         }
 
-        $methodName = explode('::', $data)[1];
+        [$className, $methodName] = $data->split('::', 2);
+        $className = $className->replace('\\\\', '\\');
 
         $scrollTextFragment = sprintf('#:~:text=%s', rawurlencode('function '.$methodName));
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $methodName.'()',
-            sprintf('%s/%s.php%s', $this->symfonyRepositoryUrl, str_replace('\\', '/', $className), $scrollTextFragment),
+            sprintf('%s/%s.php%s', $this->symfonyRepositoryUrl, $className->replace('\\', '/'), $scrollTextFragment),
             [],
             [
                 'title' => sprintf('%s::%s()', $className, $methodName),

--- a/src/Reference/PhpClassReference.php
+++ b/src/Reference/PhpClassReference.php
@@ -12,6 +12,7 @@ namespace SymfonyDocsBuilder\Reference;
 use Doctrine\RST\Environment;
 use Doctrine\RST\References\Reference;
 use Doctrine\RST\References\ResolvedReference;
+use function Symfony\Component\String\u;
 
 class PhpClassReference extends Reference
 {
@@ -29,14 +30,15 @@ class PhpClassReference extends Reference
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
-        $classnamePath = str_replace('\\', '-', strtolower($data));
+        $className = u($data)->replace('\\\\', '\\');
+
         return new ResolvedReference(
             $environment->getCurrentFileName(),
-            $data,
-            sprintf('%s/class.%s.php', $this->phpDocUrl, $classnamePath),
+            $className->afterLast('\\'),
+            sprintf('%s/class.%s.php', $this->phpDocUrl, $className->replace('\\', '-')->lower()),
             [],
             [
-                'title' => $data,
+                'title' => $className,
             ]
         );
     }

--- a/tests/fixtures/expected/blocks/references/php-class.html
+++ b/tests/fixtures/expected/blocks/references/php-class.html
@@ -1,2 +1,2 @@
 <p><a href="https://secure.php.net/manual/en/class.arrayaccess.php" class="reference external" title="ArrayAccess" rel="external noopener noreferrer" target="_blank">ArrayAccess</a></p>
-<p><a href="https://secure.php.net/manual/en/class.bcmath-number.php" class="reference external" title="BcMath\Number" rel="external noopener noreferrer" target="_blank">BcMath\Number</a></p>
+<p><a href="https://secure.php.net/manual/en/class.bcmath-number.php" class="reference external" title="BcMath\Number" rel="external noopener noreferrer" target="_blank">Number</a></p>

--- a/tests/fixtures/expected/blocks/references/php-method.html
+++ b/tests/fixtures/expected/blocks/references/php-method.html
@@ -1,1 +1,2 @@
-<p><a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale" rel="external noopener noreferrer" target="_blank">Locale::getDefault()</a></p>
+<p><a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale::getDefault()" rel="external noopener noreferrer" target="_blank">getDefault()</a></p>
+<p><a href="https://secure.php.net/manual/en/bcmath-number.add.php" class="reference external" title="BcMath\Number::add()" rel="external noopener noreferrer" target="_blank">add()</a></p>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -79,7 +79,7 @@ for more details.</p>
 methods: <a href="https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/BrowserKit/Client.php#:~:text=function%20doRequest" class="reference external" title="Symfony\Component\BrowserKit\Client::doRequest()" rel="external noopener noreferrer" target="_blank">doRequest()</a>.
 Or a namespace: <a href="https://github.com/symfony/symfony/blob/4.0/src/Symfony/Component/Validator/Constraints" class="reference external" title="Symfony\Component\Validator\Constraints" rel="external noopener noreferrer" target="_blank">Constraints</a>.
 Or a PHP function: <a href="https://secure.php.net/manual/en/function.parse-ini-file.php" class="reference external" title="parse_ini_file" rel="external noopener noreferrer" target="_blank">parse_ini_file</a>.
-Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale" rel="external noopener noreferrer" target="_blank">Locale::getDefault()</a>.</p>
+Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale::getDefault()" rel="external noopener noreferrer" target="_blank">getDefault()</a>.</p>
             </div>
         </div>
         <div class="section">

--- a/tests/fixtures/source/blocks/references/php-class.rst
+++ b/tests/fixtures/source/blocks/references/php-class.rst
@@ -1,4 +1,4 @@
 
 :phpclass:`ArrayAccess`
 
-:phpclass:`BcMath\Number`
+:phpclass:`BcMath\\Number`

--- a/tests/fixtures/source/blocks/references/php-method.rst
+++ b/tests/fixtures/source/blocks/references/php-method.rst
@@ -1,2 +1,4 @@
 
 :phpmethod:`Locale::getDefault`
+
+:phpmethod:`BcMath\\Number::add`


### PR DESCRIPTION
### Changes

- Make escaping consistent for PHP and Github references (require double backslashes, as single can be used to escape the `` ` `` character).
- Add namespace support to `:phpmethod:` (consistent with `:method:` and `:phpclass:`)
- Update PHP reference text/title to be consistent with GitHub references (e.g. strip the full namespace & only show method name)
- Use String component in all reference classes

The updates should be fully compatible with Symfony documentation. https://github.com/symfony/symfony-docs/pull/20822 is the only case where we use the new namespace features of `:phpclass:` (and this revealed the inconsistency).