### PR TITLE
Fix bug in PHP syntax highlighting

### DIFF
--- a/src/Templates/highlight.php/php.json
+++ b/src/Templates/highlight.php/php.json
@@ -7,7 +7,7 @@
         "php6",
         "php7"
     ],
-    "case_insensitive": true,
+    "case_insensitive": false,
     "keywords": "PHP_VERSION PHP_MAJOR_VERSION PHP_MINOR_VERSION PHP_RELEASE_VERSION PHP_VERSION_ID PHP_EXTRA_VERSION ZEND_THREAD_SAFE ZEND_DEBUG_BUILD PHP_ZTS PHP_DEBUG PHP_MAXPATHLEN PHP_OS PHP_OS_FAMILY PHP_SAPI PHP_EOL PHP_INT_MAX PHP_INT_MIN PHP_INT_SIZE PHP_FLOAT_DIG PHP_FLOAT_EPSILON PHP_FLOAT_MIN PHP_FLOAT_MAX DEFAULT_INCLUDE_PATH PEAR_INSTALL_DIR PEAR_EXTENSION_DIR PHP_EXTENSION_DIR PHP_PREFIX PHP_BINDIR PHP_BINARY PHP_MANDIR PHP_LIBDIR PHP_DATADIR PHP_SYSCONFDIR PHP_LOCALSTATEDIR PHP_CONFIG_FILE_PATH PHP_CONFIG_FILE_SCAN_DIR PHP_SHLIB_SUFFIX PHP_FD_SETSIZE E_ERROR E_WARNING E_PARSE E_NOTICE E_CORE_ERROR E_CORE_WARNING E_COMPILE_ERROR E_COMPILE_WARNING E_USER_ERROR E_USER_WARNING E_USER_NOTICE E_RECOVERABLE_ERROR E_DEPRECATED E_USER_DEPRECATED E_ALL E_STRICT __COMPILER_HALT_OFFSET__ PHP_WINDOWS_EVENT_CTRL_C PHP_WINDOWS_EVENT_CTRL_BREAK PHP_CLI_PROCESS_TITLE STDERR STDIN STDOUT __CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__ die echo exit include include_once print require require_once abstract and as binary break case catch class clone const continue declare default do double else elseif empty enddeclare endfor endforeach endif endswitch endwhile enum eval extends final finally for foreach from global goto if implements instanceof insteadof interface isset list match|0 new or parent private protected public readonly return switch throw trait try unset use var void while xor yield array bool boolean callable float int integer iterable mixed never numeric object real string resource self static false FALSE null NULL true TRUE",
     "contains": [
         {
@@ -16,23 +16,16 @@
             "end": "]",
             "contains": [
                 {
-                    "variants": [
+                    "begin": "\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+",
+                    "contains": [
                         {
-                            "begin": "\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+(?=\\()",
-                            "contains": [
-                                {
-                                    "begin": "\\(",
-                                    "end": "\\)",
-                                    "keywords": "array bool boolean float int integer new real string false FALSE null NULL true TRUE PHP_VERSION PHP_MAJOR_VERSION PHP_MINOR_VERSION PHP_RELEASE_VERSION PHP_VERSION_ID PHP_EXTRA_VERSION ZEND_THREAD_SAFE ZEND_DEBUG_BUILD PHP_ZTS PHP_DEBUG PHP_MAXPATHLEN PHP_OS PHP_OS_FAMILY PHP_SAPI PHP_EOL PHP_INT_MAX PHP_INT_MIN PHP_INT_SIZE PHP_FLOAT_DIG PHP_FLOAT_EPSILON PHP_FLOAT_MIN PHP_FLOAT_MAX DEFAULT_INCLUDE_PATH PEAR_INSTALL_DIR PEAR_EXTENSION_DIR PHP_EXTENSION_DIR PHP_PREFIX PHP_BINDIR PHP_BINARY PHP_MANDIR PHP_LIBDIR PHP_DATADIR PHP_SYSCONFDIR PHP_LOCALSTATEDIR PHP_CONFIG_FILE_PATH PHP_CONFIG_FILE_SCAN_DIR PHP_SHLIB_SUFFIX PHP_FD_SETSIZE E_ERROR E_WARNING E_PARSE E_NOTICE E_CORE_ERROR E_CORE_WARNING E_COMPILE_ERROR E_COMPILE_WARNING E_USER_ERROR E_USER_WARNING E_USER_NOTICE E_RECOVERABLE_ERROR E_DEPRECATED E_USER_DEPRECATED E_ALL E_STRICT __COMPILER_HALT_OFFSET__ PHP_WINDOWS_EVENT_CTRL_C PHP_WINDOWS_EVENT_CTRL_BREAK PHP_CLI_PROCESS_TITLE STDERR STDIN STDOUT __CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__",
-                                    "contains": {
-                                        "$ref": "#contains.8.contains.1.contains",
-                                        "_": "params"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "begin": "\\s*(\\\\?[A-Z][A-Za-z0-9_\\x7f-\\xff]+)+(?!\\()"
+                            "begin": "\\(",
+                            "end": "\\)",
+                            "keywords": "array bool boolean float int integer new real string false FALSE null NULL true TRUE PHP_VERSION PHP_MAJOR_VERSION PHP_MINOR_VERSION PHP_RELEASE_VERSION PHP_VERSION_ID PHP_EXTRA_VERSION ZEND_THREAD_SAFE ZEND_DEBUG_BUILD PHP_ZTS PHP_DEBUG PHP_MAXPATHLEN PHP_OS PHP_OS_FAMILY PHP_SAPI PHP_EOL PHP_INT_MAX PHP_INT_MIN PHP_INT_SIZE PHP_FLOAT_DIG PHP_FLOAT_EPSILON PHP_FLOAT_MIN PHP_FLOAT_MAX DEFAULT_INCLUDE_PATH PEAR_INSTALL_DIR PEAR_EXTENSION_DIR PHP_EXTENSION_DIR PHP_PREFIX PHP_BINDIR PHP_BINARY PHP_MANDIR PHP_LIBDIR PHP_DATADIR PHP_SYSCONFDIR PHP_LOCALSTATEDIR PHP_CONFIG_FILE_PATH PHP_CONFIG_FILE_SCAN_DIR PHP_SHLIB_SUFFIX PHP_FD_SETSIZE E_ERROR E_WARNING E_PARSE E_NOTICE E_CORE_ERROR E_CORE_WARNING E_COMPILE_ERROR E_COMPILE_WARNING E_USER_ERROR E_USER_WARNING E_USER_NOTICE E_RECOVERABLE_ERROR E_DEPRECATED E_USER_DEPRECATED E_ALL E_STRICT __COMPILER_HALT_OFFSET__ PHP_WINDOWS_EVENT_CTRL_C PHP_WINDOWS_EVENT_CTRL_BREAK PHP_CLI_PROCESS_TITLE STDERR STDIN STDOUT __CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__ __NAMESPACE__ __TRAIT__",
+                            "contains": {
+                                "$ref": "#contains.8.contains.1.contains",
+                                "_": "params"
+                            }
                         }
                     ]
                 }

--- a/tests/Templates/HighlightJsIntegrationTest.php
+++ b/tests/Templates/HighlightJsIntegrationTest.php
@@ -42,6 +42,12 @@ class HighlightJsIntegrationTest extends TestCase
             'php.output.html',
         ];
 
+        yield 'php1' => [
+            'php',
+            'php1.input.txt',
+            'php1.output.html',
+        ];
+
         yield 'twig' => [
             'twig',
             'twig.input.txt',

--- a/tests/Templates/fixtures/php1.input.txt
+++ b/tests/Templates/fixtures/php1.input.txt
@@ -1,0 +1,52 @@
+// src/Native/AppNativeConfiguration.php
+namespace App\Native;
+
+use Symfony\UX\Native\Attribute\AsNativeConfiguration;
+use Symfony\UX\Native\Attribute\AsNativeConfigurationProvider;
+use Symfony\UX\Native\Configuration\Configuration;
+use Symfony\UX\Native\Configuration\Rule;
+
+#[AsNativeConfigurationProvider]
+final class AppNativeConfiguration
+{
+    #[AsNativeConfiguration('/config/ios_v1.json')]
+    public function iosV1(): Configuration
+    {
+        return new Configuration(
+            settings: [
+                'use_local_db' => true,
+                'cable' => [
+                    'script_url' => 'https://example.com/cable.js',
+                ],
+            ],
+            rules: [
+                new Rule(
+                    patterns: ['.*'],
+                    properties: [
+                        'context' => 'default',
+                        'pull_to_refresh_enabled' => true,
+                    ],
+                ),
+            ],
+        );
+    }
+
+    #[AsNativeConfiguration('/config/android_v1.json')]
+    public function androidV1(): Configuration
+    {
+        return new Configuration(
+            settings: [
+                'use_local_db' => false,
+            ],
+            rules: [
+                new Rule(
+                    patterns: ['/articles/.*'],
+                    properties: [
+                        'context' => 'default',
+                        'pull_to_refresh_enabled' => false,
+                    ],
+                ),
+            ],
+        );
+    }
+}

--- a/tests/Templates/fixtures/php1.output.html
+++ b/tests/Templates/fixtures/php1.output.html
@@ -1,0 +1,52 @@
+<span class="hljs-comment">// src/Native/AppNativeConfiguration.php</span>
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">App</span>\<span class="hljs-title">Native</span>;
+
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">UX</span>\<span class="hljs-title">Native</span>\<span class="hljs-title">Attribute</span>\<span class="hljs-title">AsNativeConfiguration</span>;
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">UX</span>\<span class="hljs-title">Native</span>\<span class="hljs-title">Attribute</span>\<span class="hljs-title">AsNativeConfigurationProvider</span>;
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">UX</span>\<span class="hljs-title">Native</span>\<span class="hljs-title">Configuration</span>\<span class="hljs-title">Configuration</span>;
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">UX</span>\<span class="hljs-title">Native</span>\<span class="hljs-title">Configuration</span>\<span class="hljs-title">Rule</span>;
+
+<span class="hljs-meta">#[AsNativeConfigurationProvider]</span>
+<span class="hljs-keyword">final</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">AppNativeConfiguration</span>
+</span>{
+    <span class="hljs-meta">#[AsNativeConfiguration(<span class="hljs-string">'/config/ios_v1.json'</span>)]</span>
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">iosV1</span><span class="hljs-params">()</span>: <span class="hljs-title">Configuration</span>
+    </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-title invoke__">Configuration</span>(
+            <span class="hljs-attr">settings</span>: [
+                <span class="hljs-string">'use_local_db'</span> =&gt; <span class="hljs-keyword">true</span>,
+                <span class="hljs-string">'cable'</span> =&gt; [
+                    <span class="hljs-string">'script_url'</span> =&gt; <span class="hljs-string">'https://example.com/cable.js'</span>,
+                ],
+            ],
+            <span class="hljs-attr">rules</span>: [
+                <span class="hljs-keyword">new</span> <span class="hljs-title invoke__">Rule</span>(
+                    <span class="hljs-attr">patterns</span>: [<span class="hljs-string">'.*'</span>],
+                    <span class="hljs-attr">properties</span>: [
+                        <span class="hljs-string">'context'</span> =&gt; <span class="hljs-string">'default'</span>,
+                        <span class="hljs-string">'pull_to_refresh_enabled'</span> =&gt; <span class="hljs-keyword">true</span>,
+                    ],
+                ),
+            ],
+        );
+    }
+
+    <span class="hljs-meta">#[AsNativeConfiguration(<span class="hljs-string">'/config/android_v1.json'</span>)]</span>
+    <span class="hljs-keyword">public</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">androidV1</span><span class="hljs-params">()</span>: <span class="hljs-title">Configuration</span>
+    </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-title invoke__">Configuration</span>(
+            <span class="hljs-attr">settings</span>: [
+                <span class="hljs-string">'use_local_db'</span> =&gt; <span class="hljs-keyword">false</span>,
+            ],
+            <span class="hljs-attr">rules</span>: [
+                <span class="hljs-keyword">new</span> <span class="hljs-title invoke__">Rule</span>(
+                    <span class="hljs-attr">patterns</span>: [<span class="hljs-string">'/articles/.*'</span>],
+                    <span class="hljs-attr">properties</span>: [
+                        <span class="hljs-string">'context'</span> =&gt; <span class="hljs-string">'default'</span>,
+                        <span class="hljs-string">'pull_to_refresh_enabled'</span> =&gt; <span class="hljs-keyword">false</span>,
+                    ],
+                ),
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Don't ask me why and how. I don't see why it breaks in this UX example, but doesn't in e.g. https://symfony.com/doc/current/messenger.html#creating-a-message-handler And I also don't see how this change fixes it. But it fixes it, and it doesn't appear to break any other PHP attributes in the test suite of this library (which is quite extensive).