### PR TITLE
Allow configuring the Symfony AI and UX versions used in class links

### DIFF
--- a/src/BuildConfig.php
+++ b/src/BuildConfig.php
@@ -18,10 +18,14 @@ class BuildConfig
     private const PHP_DOC_URL = 'https://secure.php.net/manual/en';
     private const SYMFONY_REPOSITORY_URL = 'https://github.com/symfony/symfony/blob/{symfonyVersion}/src';
     private const SYMFONY_DOC_URL = 'https://symfony.com/doc/{symfonyVersion}';
+    private const SYMFONY_AI_REPOSITORY_URL = 'https://github.com/symfony/ai/blob/{symfonyAiVersion}/src';
+    private const SYMFONY_UX_REPOSITORY_URL = 'https://github.com/symfony/ux/blob/{symfonyUxVersion}/src';
 
     private $useBuildCache;
     private $theme;
     private $symfonyVersion;
+    private $symfonyAiVersion;
+    private $symfonyUxVersion;
     private $contentDir;
     private $outputDir;
     private $cacheDir;
@@ -40,6 +44,8 @@ class BuildConfig
         $this->useBuildCache = true;
         $this->theme = Configuration::THEME_DEFAULT;
         $this->symfonyVersion = '4.4';
+        $this->symfonyAiVersion = 'main';
+        $this->symfonyUxVersion = '2.x';
         $this->excludedPaths = [];
         $this->imagesPublicPrefix = '';
         $this->contentIsString = false;
@@ -73,6 +79,16 @@ class BuildConfig
         return $this->symfonyVersion;
     }
 
+    public function getSymfonyAiVersion(): string
+    {
+        return $this->symfonyAiVersion;
+    }
+
+    public function getSymfonyUxVersion(): string
+    {
+        return $this->symfonyUxVersion;
+    }
+
     public function getPhpDocUrl(): string
     {
         return self::PHP_DOC_URL;
@@ -81,6 +97,16 @@ class BuildConfig
     public function getSymfonyRepositoryUrl(): string
     {
         return str_replace('{symfonyVersion}', $this->getSymfonyVersion(), self::SYMFONY_REPOSITORY_URL);
+    }
+
+    public function getSymfonyAiRepositoryUrl(): string
+    {
+        return str_replace('{symfonyAiVersion}', $this->getSymfonyAiVersion(), self::SYMFONY_AI_REPOSITORY_URL);
+    }
+
+    public function getSymfonyUxRepositoryUrl(): string
+    {
+        return str_replace('{symfonyUxVersion}', $this->getSymfonyUxVersion(), self::SYMFONY_UX_REPOSITORY_URL);
     }
 
     public function getSymfonyDocUrl(): string
@@ -147,6 +173,20 @@ class BuildConfig
     public function setSymfonyVersion(string $version): self
     {
         $this->symfonyVersion = $version;
+
+        return $this;
+    }
+
+    public function setSymfonyAiVersion(string $version): self
+    {
+        $this->symfonyAiVersion = $version;
+
+        return $this;
+    }
+
+    public function setSymfonyUxVersion(string $version): self
+    {
+        $this->symfonyUxVersion = $version;
 
         return $this;
     }

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -102,7 +102,11 @@ final class KernelFactory
     private static function getReferences(BuildConfig $buildConfig): array
     {
         return [
-            new SymfonyReferences\ClassReference($buildConfig->getSymfonyRepositoryUrl()),
+            new SymfonyReferences\ClassReference(
+                $buildConfig->getSymfonyRepositoryUrl(),
+                $buildConfig->getSymfonyAiRepositoryUrl(),
+                $buildConfig->getSymfonyUxRepositoryUrl()
+            ),
             new SymfonyReferences\MethodReference($buildConfig->getSymfonyRepositoryUrl()),
             new SymfonyReferences\NamespaceReference($buildConfig->getSymfonyRepositoryUrl()),
             new SymfonyReferences\PhpFunctionReference($buildConfig->getPhpDocUrl()),

--- a/src/Reference/ClassReference.php
+++ b/src/Reference/ClassReference.php
@@ -17,10 +17,14 @@ use function Symfony\Component\String\u;
 class ClassReference extends Reference
 {
     private $symfonyRepositoryUrl;
+    private $symfonyAiRepositoryUrl;
+    private $symfonyUxRepositoryUrl;
 
-    public function __construct(string $symfonyRepositoryUrl)
+    public function __construct(string $symfonyRepositoryUrl, string $symfonyAiRepositoryUrl, string $symfonyUxRepositoryUrl)
     {
         $this->symfonyRepositoryUrl = $symfonyRepositoryUrl;
+        $this->symfonyAiRepositoryUrl = $symfonyAiRepositoryUrl;
+        $this->symfonyUxRepositoryUrl = $symfonyUxRepositoryUrl;
     }
 
     public function getName(): string
@@ -46,7 +50,7 @@ class ClassReference extends Reference
             $monorepoSubRepository = $monorepoSubRepository->kebab()->lower();
             $classRelativePath = $classRelativePath->replace('\\', '/');
 
-            $url = \sprintf('https://github.com/symfony/ai/blob/main/src/%s/src/%s.php', $monorepoSubRepository, $classRelativePath);
+            $url = \sprintf('%s/%s/src/%s.php', $this->symfonyAiRepositoryUrl, $monorepoSubRepository, $classRelativePath);
         /**
          * Symfony UX classes require some special handling because of its monorepo structure. Example:
          *
@@ -58,7 +62,7 @@ class ClassReference extends Reference
             [$monorepoSubRepository, $classRelativePath] = $classPath->split('\\', 2);
             $classRelativePath = $classRelativePath->replace('\\', '/');
 
-            $url = \sprintf('https://github.com/symfony/ux/blob/2.x/src/%s/src/%s.php', $monorepoSubRepository, $classRelativePath);
+            $url = \sprintf('%s/%s/src/%s.php', $this->symfonyUxRepositoryUrl, $monorepoSubRepository, $classRelativePath);
         } else {
             $url = sprintf('%s/%s.php', $this->symfonyRepositoryUrl, $className->replace('\\', '/'));
         }

--- a/tests/Reference/ClassReferenceTest.php
+++ b/tests/Reference/ClassReferenceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Tests\Reference;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use PHPUnit\Framework\TestCase;
+use SymfonyDocsBuilder\BuildConfig;
+use SymfonyDocsBuilder\Reference\ClassReference;
+
+class ClassReferenceTest extends TestCase
+{
+    /**
+     * @dataProvider getDefaultVersionTests
+     */
+    public function testResolveWithTheDefaultVersions(string $className, string $expectedUrl)
+    {
+        $this->assertSame($expectedUrl, $this->resolve(new BuildConfig(), $className));
+    }
+
+    public function getDefaultVersionTests()
+    {
+        yield 'symfony_ai' => [
+            'Symfony\AI\Agent\Memory\StaticMemoryProvider',
+            'https://github.com/symfony/ai/blob/main/src/agent/src/Memory/StaticMemoryProvider.php',
+        ];
+        yield 'symfony_ux' => [
+            'Symfony\UX\Chartjs\Twig\ChartExtension',
+            'https://github.com/symfony/ux/blob/2.x/src/Chartjs/src/Twig/ChartExtension.php',
+        ];
+    }
+
+    /**
+     * @dataProvider getConfiguredVersionTests
+     */
+    public function testResolveWithTheConfiguredVersions(string $className, string $expectedUrl)
+    {
+        $buildConfig = (new BuildConfig())
+            ->setSymfonyVersion('7.4')
+            ->setSymfonyAiVersion('1.0')
+            ->setSymfonyUxVersion('3.x');
+
+        $this->assertSame($expectedUrl, $this->resolve($buildConfig, $className));
+    }
+
+    public function getConfiguredVersionTests()
+    {
+        yield 'symfony' => [
+            'Symfony\Component\HttpKernel\Kernel',
+            'https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/HttpKernel/Kernel.php',
+        ];
+        yield 'symfony_ai' => [
+            'Symfony\AI\Agent\Memory\StaticMemoryProvider',
+            'https://github.com/symfony/ai/blob/1.0/src/agent/src/Memory/StaticMemoryProvider.php',
+        ];
+        yield 'symfony_ai_bundle' => [
+            'Symfony\AI\AiBundle\Security\Attribute\IsGrantedTool',
+            'https://github.com/symfony/ai/blob/1.0/src/ai-bundle/src/Security/Attribute/IsGrantedTool.php',
+        ];
+        yield 'symfony_ux' => [
+            'Symfony\UX\Chartjs\Twig\ChartExtension',
+            'https://github.com/symfony/ux/blob/3.x/src/Chartjs/src/Twig/ChartExtension.php',
+        ];
+    }
+
+    private function resolve(BuildConfig $buildConfig, string $className): string
+    {
+        $reference = new ClassReference(
+            $buildConfig->getSymfonyRepositoryUrl(),
+            $buildConfig->getSymfonyAiRepositoryUrl(),
+            $buildConfig->getSymfonyUxRepositoryUrl()
+        );
+
+        return $reference->resolve(new Environment(new Configuration()), $className)->getUrl();
+    }
+}


### PR DESCRIPTION
The `:class:` directive supports Symfony AI (#196) and Symfony UX (#198) classes, but the generated URLs have their versions hardcoded to `main` and `2.x` in `ClassReference`. This makes them configurable, following the same pattern as the Symfony version.

`BuildConfig` gains two versions, defaulting to the current values, so nothing changes unless you opt in:

```php
$buildConfig = (new BuildConfig())
    ->setSymfonyVersion('7.4')
    ->setSymfonyAiVersion('1.0')   // defaults to 'main'
    ->setSymfonyUxVersion('3.x')   // defaults to '2.x'
;
```

The two URLs become placeholder constants (like `SYMFONY_REPOSITORY_URL`), `ClassReference` receives them instead of hardcoding the branches, and `KernelFactory` — its only instantiation site — passes them along.

About the tests:

* the existing `blocks/references/class` fixture passes untouched, which shows the defaults preserve the current output;
* the new tests cover both monorepos, including the slugged sub-repository case (`Symfony\AI\AiBundle` → `ai-bundle`);
* I double-checked they aren't vacuous: putting the branches back in `ClassReference` makes exactly the 3 configured AI/UX cases fail, while the Symfony one and the defaults stay green.

One thing I noticed while tracing the wiring, and deliberately left alone: `Application::__construct()` takes `$symfonyVersion` but never passes it to `BuildConfig`, so the `--symfony-version` CLI option looks like it has no effect. That's a separate matter — happy to open an issue if you'd like.

Fixes #199

Thanks for maintaining the tooling that keeps the docs building. 🙂