### PR TITLE
Use the maxdepth option of the toctree directive to count the visible TOC items

### DIFF
--- a/src/BuildConfig.php
+++ b/src/BuildConfig.php
@@ -18,10 +18,14 @@ class BuildConfig
     private const PHP_DOC_URL = 'https://secure.php.net/manual/en';
     private const SYMFONY_REPOSITORY_URL = 'https://github.com/symfony/symfony/blob/{symfonyVersion}/src';
     private const SYMFONY_DOC_URL = 'https://symfony.com/doc/{symfonyVersion}';
+    private const SYMFONY_AI_REPOSITORY_URL = 'https://github.com/symfony/ai/blob/{symfonyAiVersion}/src';
+    private const SYMFONY_UX_REPOSITORY_URL = 'https://github.com/symfony/ux/blob/{symfonyUxVersion}/src';
 
     private $useBuildCache;
     private $theme;
     private $symfonyVersion;
+    private $symfonyAiVersion;
+    private $symfonyUxVersion;
     private $contentDir;
     private $outputDir;
     private $cacheDir;
@@ -40,6 +44,8 @@ class BuildConfig
         $this->useBuildCache = true;
         $this->theme = Configuration::THEME_DEFAULT;
         $this->symfonyVersion = '4.4';
+        $this->symfonyAiVersion = 'main';
+        $this->symfonyUxVersion = '2.x';
         $this->excludedPaths = [];
         $this->imagesPublicPrefix = '';
         $this->contentIsString = false;
@@ -73,6 +79,16 @@ class BuildConfig
         return $this->symfonyVersion;
     }
 
+    public function getSymfonyAiVersion(): string
+    {
+        return $this->symfonyAiVersion;
+    }
+
+    public function getSymfonyUxVersion(): string
+    {
+        return $this->symfonyUxVersion;
+    }
+
     public function getPhpDocUrl(): string
     {
         return self::PHP_DOC_URL;
@@ -81,6 +97,16 @@ class BuildConfig
     public function getSymfonyRepositoryUrl(): string
     {
         return str_replace('{symfonyVersion}', $this->getSymfonyVersion(), self::SYMFONY_REPOSITORY_URL);
+    }
+
+    public function getSymfonyAiRepositoryUrl(): string
+    {
+        return str_replace('{symfonyAiVersion}', $this->getSymfonyAiVersion(), self::SYMFONY_AI_REPOSITORY_URL);
+    }
+
+    public function getSymfonyUxRepositoryUrl(): string
+    {
+        return str_replace('{symfonyUxVersion}', $this->getSymfonyUxVersion(), self::SYMFONY_UX_REPOSITORY_URL);
     }
 
     public function getSymfonyDocUrl(): string
@@ -147,6 +173,20 @@ class BuildConfig
     public function setSymfonyVersion(string $version): self
     {
         $this->symfonyVersion = $version;
+
+        return $this;
+    }
+
+    public function setSymfonyAiVersion(string $version): self
+    {
+        $this->symfonyAiVersion = $version;
+
+        return $this;
+    }
+
+    public function setSymfonyUxVersion(string $version): self
+    {
+        $this->symfonyUxVersion = $version;
 
         return $this;
     }

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -102,7 +102,11 @@ final class KernelFactory
     private static function getReferences(BuildConfig $buildConfig): array
     {
         return [
-            new SymfonyReferences\ClassReference($buildConfig->getSymfonyRepositoryUrl()),
+            new SymfonyReferences\ClassReference(
+                $buildConfig->getSymfonyRepositoryUrl(),
+                $buildConfig->getSymfonyAiRepositoryUrl(),
+                $buildConfig->getSymfonyUxRepositoryUrl()
+            ),
             new SymfonyReferences\MethodReference($buildConfig->getSymfonyRepositoryUrl()),
             new SymfonyReferences\NamespaceReference($buildConfig->getSymfonyRepositoryUrl()),
             new SymfonyReferences\PhpFunctionReference($buildConfig->getPhpDocUrl()),

--- a/src/Reference/ClassReference.php
+++ b/src/Reference/ClassReference.php
@@ -17,10 +17,14 @@ use function Symfony\Component\String\u;
 class ClassReference extends Reference
 {
     private $symfonyRepositoryUrl;
+    private $symfonyAiRepositoryUrl;
+    private $symfonyUxRepositoryUrl;
 
-    public function __construct(string $symfonyRepositoryUrl)
+    public function __construct(string $symfonyRepositoryUrl, string $symfonyAiRepositoryUrl, string $symfonyUxRepositoryUrl)
     {
         $this->symfonyRepositoryUrl = $symfonyRepositoryUrl;
+        $this->symfonyAiRepositoryUrl = $symfonyAiRepositoryUrl;
+        $this->symfonyUxRepositoryUrl = $symfonyUxRepositoryUrl;
     }
 
     public function getName(): string
@@ -46,7 +50,7 @@ class ClassReference extends Reference
             $monorepoSubRepository = $monorepoSubRepository->kebab()->lower();
             $classRelativePath = $classRelativePath->replace('\\', '/');
 
-            $url = \sprintf('https://github.com/symfony/ai/blob/main/src/%s/src/%s.php', $monorepoSubRepository, $classRelativePath);
+            $url = \sprintf('%s/%s/src/%s.php', $this->symfonyAiRepositoryUrl, $monorepoSubRepository, $classRelativePath);
         /**
          * Symfony UX classes require some special handling because of its monorepo structure. Example:
          *
@@ -58,7 +62,7 @@ class ClassReference extends Reference
             [$monorepoSubRepository, $classRelativePath] = $classPath->split('\\', 2);
             $classRelativePath = $classRelativePath->replace('\\', '/');
 
-            $url = \sprintf('https://github.com/symfony/ux/blob/2.x/src/%s/src/%s.php', $monorepoSubRepository, $classRelativePath);
+            $url = \sprintf('%s/%s/src/%s.php', $this->symfonyUxRepositoryUrl, $monorepoSubRepository, $classRelativePath);
         } else {
             $url = sprintf('%s/%s.php', $this->symfonyRepositoryUrl, $className->replace('\\', '/'));
         }

--- a/src/Templates/default/html/toc.html.twig
+++ b/src/Templates/default/html/toc.html.twig
@@ -1,4 +1,4 @@
-{% set toc_options = toc_options(tocItems) %}
+{% set toc_options = toc_options(tocItems, tocNode.depth) %}
 <div class="toctree-wrapper toc-size-{{ toc_options.size }}">
     {% include "toc-level.html.twig" %}
 </div>

--- a/src/Twig/TocExtension.php
+++ b/src/Twig/TocExtension.php
@@ -14,6 +14,11 @@ use Twig\TwigFunction;
 
 class TocExtension extends AbstractExtension
 {
+    /**
+     * Same default as Doctrine\RST\Nodes\TocNode::DEFAULT_DEPTH.
+     */
+    private const DEFAULT_MAX_DEPTH = 2;
+
     public function getFunctions(): array
     {
         return [
@@ -21,13 +26,15 @@ class TocExtension extends AbstractExtension
         ];
     }
 
-    public static function getOptions(array $toc): array
+    /**
+     * $maxDepth defaults to the same value as the 'maxdepth' option of the
+     * 'toctree' directive, which is what the TOC of a page is built upon.
+     *
+     * @see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
+     */
+    public static function getOptions(array $toc, int $maxDepth = self::DEFAULT_MAX_DEPTH): array
     {
         $flattendToc = self::flattenToc($toc);
-        // FIXME: this hardcoded '2' value should instead be obtained
-        // automatically using the 'maxdepth' option of 'toctree' directive.
-        // See https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
-        $maxDepth = 2;
         $numVisibleItems = 0;
         foreach ($flattendToc as $tocItem) {
             if ($tocItem['level'] > $maxDepth) {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -75,6 +75,10 @@ class IntegrationTest extends AbstractIntegrationTest
             'folder' => 'toctree',
         ];
 
+        yield 'toctree-maxdepth' => [
+            'folder' => 'toctree-maxdepth',
+        ];
+
         yield 'ref-reference' => [
             'folder' => 'ref-reference',
         ];

--- a/tests/Reference/ClassReferenceTest.php
+++ b/tests/Reference/ClassReferenceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Tests\Reference;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use PHPUnit\Framework\TestCase;
+use SymfonyDocsBuilder\BuildConfig;
+use SymfonyDocsBuilder\Reference\ClassReference;
+
+class ClassReferenceTest extends TestCase
+{
+    /**
+     * @dataProvider getDefaultVersionTests
+     */
+    public function testResolveWithTheDefaultVersions(string $className, string $expectedUrl)
+    {
+        $this->assertSame($expectedUrl, $this->resolve(new BuildConfig(), $className));
+    }
+
+    public function getDefaultVersionTests()
+    {
+        yield 'symfony_ai' => [
+            'Symfony\AI\Agent\Memory\StaticMemoryProvider',
+            'https://github.com/symfony/ai/blob/main/src/agent/src/Memory/StaticMemoryProvider.php',
+        ];
+        yield 'symfony_ux' => [
+            'Symfony\UX\Chartjs\Twig\ChartExtension',
+            'https://github.com/symfony/ux/blob/2.x/src/Chartjs/src/Twig/ChartExtension.php',
+        ];
+    }
+
+    /**
+     * @dataProvider getConfiguredVersionTests
+     */
+    public function testResolveWithTheConfiguredVersions(string $className, string $expectedUrl)
+    {
+        $buildConfig = (new BuildConfig())
+            ->setSymfonyVersion('7.4')
+            ->setSymfonyAiVersion('1.0')
+            ->setSymfonyUxVersion('3.x');
+
+        $this->assertSame($expectedUrl, $this->resolve($buildConfig, $className));
+    }
+
+    public function getConfiguredVersionTests()
+    {
+        yield 'symfony' => [
+            'Symfony\Component\HttpKernel\Kernel',
+            'https://github.com/symfony/symfony/blob/7.4/src/Symfony/Component/HttpKernel/Kernel.php',
+        ];
+        yield 'symfony_ai' => [
+            'Symfony\AI\Agent\Memory\StaticMemoryProvider',
+            'https://github.com/symfony/ai/blob/1.0/src/agent/src/Memory/StaticMemoryProvider.php',
+        ];
+        yield 'symfony_ai_bundle' => [
+            'Symfony\AI\AiBundle\Security\Attribute\IsGrantedTool',
+            'https://github.com/symfony/ai/blob/1.0/src/ai-bundle/src/Security/Attribute/IsGrantedTool.php',
+        ];
+        yield 'symfony_ux' => [
+            'Symfony\UX\Chartjs\Twig\ChartExtension',
+            'https://github.com/symfony/ux/blob/3.x/src/Chartjs/src/Twig/ChartExtension.php',
+        ];
+    }
+
+    private function resolve(BuildConfig $buildConfig, string $className): string
+    {
+        $reference = new ClassReference(
+            $buildConfig->getSymfonyRepositoryUrl(),
+            $buildConfig->getSymfonyAiRepositoryUrl(),
+            $buildConfig->getSymfonyUxRepositoryUrl()
+        );
+
+        return $reference->resolve(new Environment(new Configuration()), $className)->getUrl();
+    }
+}

--- a/tests/Twig/TocExtensionTest.php
+++ b/tests/Twig/TocExtensionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use SymfonyDocsBuilder\Twig\TocExtension;
+
+class TocExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider getMaxDepthTests
+     */
+    public function testItemsDeeperThanMaxDepthAreNotCounted(int $maxDepth, int $expectedNumVisibleItems, string $expectedSize)
+    {
+        $options = TocExtension::getOptions($this->createToc(), $maxDepth);
+
+        $this->assertSame($maxDepth, $options['maxDepth']);
+        $this->assertSame($expectedNumVisibleItems, $options['numVisibleItems']);
+        $this->assertSame($expectedSize, $options['size']);
+    }
+
+    public function getMaxDepthTests()
+    {
+        // the TOC below has 2 items on level 1, 4 on level 2 and 8 on level 3
+        yield 'level 1 only' => [1, 2, 'md'];
+        yield 'levels 1 and 2' => [2, 6, 'md'];
+        yield 'levels 1 to 3' => [3, 14, 'lg'];
+    }
+
+    public function testTheDefaultMaxDepthIsTwo()
+    {
+        $options = TocExtension::getOptions($this->createToc());
+
+        $this->assertSame(2, $options['maxDepth']);
+        $this->assertSame(6, $options['numVisibleItems']);
+    }
+
+    /**
+     * Builds a TOC with 2 items on level 1, each having 2 children on level 2,
+     * each of them having 2 children on level 3.
+     */
+    private function createToc(): array
+    {
+        $toc = [];
+
+        for ($i = 1; $i <= 2; ++$i) {
+            $level1 = $this->createItem(1);
+
+            for ($j = 1; $j <= 2; ++$j) {
+                $level2 = $this->createItem(2);
+
+                for ($k = 1; $k <= 2; ++$k) {
+                    $level2['children'][] = $this->createItem(3);
+                }
+
+                $level1['children'][] = $level2;
+            }
+
+            $toc[] = $level1;
+        }
+
+        return $toc;
+    }
+
+    private function createItem(int $level): array
+    {
+        return ['level' => $level, 'children' => []];
+    }
+}

--- a/tests/fixtures/expected/toctree-maxdepth/index.html
+++ b/tests/fixtures/expected/toctree-maxdepth/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="toctree-max-depth"><a class="headerlink" href="#toctree-max-depth" title="Permalink to this headline">Toctree Max Depth</a></h1>
+<div class="toctree-wrapper toc-size-lg">
+    <ul class="toctree toctree-level-1 toctree-length-2">
+            <li>
+    <a href="deep_one.html">Deep one</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_one.html#section-a">Section A</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_one.html#subsection-a1">Subsection A1</a>
+
+    </li>
+            <li>
+    <a href="deep_one.html#subsection-a2">Subsection A2</a>
+
+    </li>
+    </ul>
+    </li>
+            <li>
+    <a href="deep_one.html#section-b">Section B</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_one.html#subsection-b1">Subsection B1</a>
+
+    </li>
+            <li>
+    <a href="deep_one.html#subsection-b2">Subsection B2</a>
+
+    </li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+            <li>
+    <a href="deep_two.html">Deep two</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_two.html#section-a">Section A</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_two.html#subsection-a1">Subsection A1</a>
+
+    </li>
+            <li>
+    <a href="deep_two.html#subsection-a2">Subsection A2</a>
+
+    </li>
+    </ul>
+    </li>
+            <li>
+    <a href="deep_two.html#section-b">Section B</a>
+
+            <ul class="toctree toctree-level-2 toctree-length-2">
+            <li>
+    <a href="deep_two.html#subsection-b1">Subsection B1</a>
+
+    </li>
+            <li>
+    <a href="deep_two.html#subsection-b2">Subsection B2</a>
+
+    </li>
+    </ul>
+    </li>
+    </ul>
+    </li>
+    </ul>
+</div>
+</div>
+
+    </body>
+</html>

--- a/tests/fixtures/source/toctree-maxdepth/deep_one.rst
+++ b/tests/fixtures/source/toctree-maxdepth/deep_one.rst
@@ -1,0 +1,20 @@
+Deep one
+=========
+
+Section A
+---------
+
+Subsection A1
+~~~~~~~~~~~~~
+
+Subsection A2
+~~~~~~~~~~~~~
+
+Section B
+---------
+
+Subsection B1
+~~~~~~~~~~~~~
+
+Subsection B2
+~~~~~~~~~~~~~

--- a/tests/fixtures/source/toctree-maxdepth/deep_two.rst
+++ b/tests/fixtures/source/toctree-maxdepth/deep_two.rst
@@ -1,0 +1,20 @@
+Deep two
+=========
+
+Section A
+---------
+
+Subsection A1
+~~~~~~~~~~~~~
+
+Subsection A2
+~~~~~~~~~~~~~
+
+Section B
+---------
+
+Subsection B1
+~~~~~~~~~~~~~
+
+Subsection B2
+~~~~~~~~~~~~~

--- a/tests/fixtures/source/toctree-maxdepth/index.rst
+++ b/tests/fixtures/source/toctree-maxdepth/index.rst
@@ -1,0 +1,8 @@
+Toctree Max Depth
+=================
+
+.. toctree::
+    :maxdepth: 3
+
+    deep_one
+    deep_two


### PR DESCRIPTION
Fixes #106, which tracked the `FIXME` left behind in #102:

```php
// FIXME: this hardcoded '2' value should instead be obtained
// automatically using the 'maxdepth' option of 'toctree' directive.
$maxDepth = 2;
```

Good news: everything needed was already there. `TocNode::getDepth()` reads the directive's `maxdepth` option (falling back to `2`), and `TocNodeRenderer` already passes `tocNode` to `toc.html.twig` — it just wasn't being used. So `toc_options()` now takes the depth as an argument:

```twig
{% set toc_options = toc_options(tocItems, tocNode.depth) %}
```

**What was actually broken:** with `:maxdepth: 3` or more, the deeper items *are* rendered but were *not counted* as visible, so `numVisibleItems` was too low and the TOC got the wrong `toc-size-*` class — i.e. the wrong number of columns. That is exactly the symptom described in #102. A toctree with `:maxdepth: 1` or `2` is unaffected, since the renderer never builds items below the depth anyway.

The parameter defaults to `2`, so `JsonGenerator` — whose TOC is crawled from `h2`/`h3` and therefore only ever has levels 1 and 2 — keeps behaving exactly as before.

**Tests:**

* a unit test on `TocExtension` pinning the count per depth (2 items on level 1, 4 on level 2, 8 on level 3 → 2 / 6 / 14 visible for maxdepth 1 / 2 / 3), plus the default;
* an integration fixture (`toctree-maxdepth`) with a `:maxdepth: 3` toctree, sized so the bug is visible: 6 counted items before (`toc-size-md`), 14 after (`toc-size-lg`).

I checked the fixture actually fails without the fix — it reports `toc-size-lg` expected, `toc-size-md` given. Full suite green: 79 tests, 176 assertions (74 before).

Thanks for the tool — the docs wouldn't build without it. 🙂