### PR TITLE
Add a progress bar with a maximum for the rendering phase

### DIFF
--- a/src/Listener/BuildProgressListener.php
+++ b/src/Listener/BuildProgressListener.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace SymfonyDocsBuilder\Listener;
 
 use Doctrine\Common\EventManager;
+use Doctrine\RST\Event\PostBuildRenderEvent;
+use Doctrine\RST\Event\PostNodeRenderEvent;
 use Doctrine\RST\Event\PostParseDocumentEvent;
 use Doctrine\RST\Event\PreBuildParseEvent;
 use Doctrine\RST\Event\PreBuildRenderEvent;
@@ -23,6 +25,8 @@ class BuildProgressListener
     private $io;
     private $progressBar;
     private $parsedFiles = [];
+    private $renderProgressBar;
+    private $renderedFiles = [];
 
     public function __construct(SymfonyStyle $io)
     {
@@ -44,9 +48,21 @@ class BuildProgressListener
             $this
         );
 
-        // tries to handle progress bar for "rendering"
+        // sets up the "rendering" progress bar
         $eventManager->addEventListener(
             [PreBuildRenderEvent::PRE_BUILD_RENDER],
+            $this
+        );
+
+        // advances the "rendering" progress bar
+        $eventManager->addEventListener(
+            [PostNodeRenderEvent::POST_NODE_RENDER],
+            $this
+        );
+
+        // finishes the "rendering" progress bar
+        $eventManager->addEventListener(
+            [PostBuildRenderEvent::POST_BUILD_RENDER],
             $this
         );
     }
@@ -73,13 +89,53 @@ class BuildProgressListener
         }
     }
 
-    public function preBuildRender()
+    /**
+     * Called after parsing: finishes the "parse" progress bar and
+     * initializes the "rendering" one.
+     */
+    public function preBuildRender(PreBuildRenderEvent $event)
     {
         // finishes the "parse" progress bar
         $this->progressBar->finish();
 
         $this->io->newLine(2);
-        $this->io->note('Rendering the HTML files...');
-        // TODO: create a proper progress bar for rendering
+
+        $renderCount = \count($event->getBuilder()->getDocuments()->getAll());
+        $this->io->note(sprintf('Rendering %d HTML files', $renderCount));
+
+        $this->renderProgressBar = new ProgressBar($this->io);
+        $this->renderProgressBar->setMaxSteps($renderCount);
+    }
+
+    /**
+     * The parser doesn't dispatch any event per rendered document, so the
+     * progress is tracked by looking at the file each rendered node belongs to.
+     */
+    public function postNodeRender(PostNodeRenderEvent $event): void
+    {
+        // nodes are also rendered before the "rendering" phase starts
+        if (null === $this->renderProgressBar) {
+            return;
+        }
+
+        $environment = $event->getRenderedNode()->getNode()->getEnvironment();
+
+        if (null === $environment) {
+            return;
+        }
+
+        $file = $environment->getCurrentFileName();
+
+        if (!\in_array($file, $this->renderedFiles, true)) {
+            $this->renderedFiles[] = $file;
+            $this->renderProgressBar->advance();
+        }
+    }
+
+    public function postBuildRender()
+    {
+        $this->renderProgressBar->finish();
+
+        $this->io->newLine(2);
     }
 }

--- a/tests/Command/BuildDocsCommandTest.php
+++ b/tests/Command/BuildDocsCommandTest.php
@@ -40,6 +40,11 @@ class BuildDocsCommandTest extends TestCase
 
         $this->assertStringContainsString('[OK] Build complete', $output);
 
+        // the "parsing" and "rendering" progress bars both know how many files they have to handle
+        $this->assertStringContainsString('Start parsing 3 out-of-date rst files', $output);
+        $this->assertStringContainsString('Rendering 3 HTML files', $output);
+        $this->assertStringContainsString('3/3', $output);
+
         $this->assertTrue($filesystem->exists(sprintf('%s/_images/symfony-logo.png', $outputDir)));
 
         $output = $this->executeCommand(


### PR DESCRIPTION
Fixes #19, and removes the `// TODO: create a proper progress bar for rendering` in `BuildProgressListener`.

Today the parsing phase gets a real progress bar, while rendering only prints a static note:

```
 ! [NOTE] Rendering the HTML files...
```

Now it gets a bar that knows where it's going:

```
 ! [NOTE] Rendering 3 HTML files

 3/3 [============================] 100%
```

**How, since the parser has no per-document render event.** `Documents::render()` loops over the documents without dispatching anything, and `DocumentNode::renderDocument()` bypasses `Node::render()`, so there's no "document rendered" signal to hook into. But there is enough to work with:

* the **maximum** comes from `PreBuildRenderEvent` → `getBuilder()->getDocuments()->getAll()`, which is exactly the set of documents about to be rendered;
* the **progress** is tracked on `POST_NODE_RENDER` by looking at the file each rendered node belongs to, advancing once per file — the same "files already seen" approach the parsing bar already uses in `postParseDocument()`;
* the bar is finished on `POST_BUILD_RENDER`.

Nodes are also rendered outside the rendering phase, so the listener ignores them until the bar exists.

**Tests:** `BuildDocsCommandTest` now asserts both bars announce their file count and reach it. Verified the assertions fail without the change (the output only contains the old static note). Full suite green: 68 tests, 157 assertions.

---

Unrelated, but I ran into it while testing this and it seems worth flagging: **`bin/docs-builder` is currently broken** on Symfony 8 — `Application::add()` was removed in favour of `addCommand()`, so the binary dies immediately:

```
PHP Fatal error: Call to undefined method Symfony\Component\Console\Application::add() in src/Application.php:38
```

The test suite doesn't catch it because it drives the command through `CommandTester` rather than the binary. Happy to send a separate PR if you'd like.