### PR TITLE
Fix the binary being broken with Symfony Console 8

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -35,7 +35,16 @@ class Application
             false === getenv('SYMFONY_VERSION') ? 'master' : getenv('SYMFONY_VERSION')
         );
         $this->application->getDefinition()->addOption($inputOption);
-        $this->application->add(new BuildDocsCommand($this->buildConfig));
+
+        $command = new BuildDocsCommand($this->buildConfig);
+
+        // Application::add() was deprecated in Symfony 7.4 and removed in 8.0,
+        // in favor of Application::addCommand(), introduced in 7.4
+        if (method_exists($this->application, 'addCommand')) {
+            $this->application->addCommand($command);
+        } else {
+            $this->application->add($command);
+        }
 
         return $this->application->run($input);
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * The rest of the test suite drives the command through CommandTester, so it
+ * never runs the binary itself. This makes sure the binary at least boots.
+ */
+class ApplicationTest extends TestCase
+{
+    public function testTheBinaryRegistersTheBuildDocsCommand()
+    {
+        $process = new Process([\PHP_BINARY, __DIR__.'/../bin/docs-builder', 'list', '--no-ansi']);
+        $process->run();
+
+        $this->assertSame(
+            0,
+            $process->getExitCode(),
+            sprintf("The binary failed to run:\n%s", $process->getErrorOutput())
+        );
+        $this->assertStringContainsString('build:docs', $process->getOutput());
+    }
+}


### PR DESCRIPTION
As mentioned in #208: `bin/docs-builder` currently dies on startup with Symfony Console 8.

```
$ php bin/docs-builder list
PHP Fatal error: Call to undefined method Symfony\Component\Console\Application::add() in src/Application.php:38
```

`Application::add()` was deprecated in Symfony 7.4 in favor of `addCommand()`, and removed in 8.0. Since composer.json allows `symfony/console: ^5.2 || ^6.0 || ^7.0 || ^8.0`, the call is guarded rather than swapped outright — `addCommand()` only exists from 7.4 on:

```php
if (method_exists($this->application, 'addCommand')) {
    $this->application->addCommand($command);
} else {
    $this->application->add($command);
}
```

**Why CI never caught this:** the whole suite drives the command through `CommandTester`, so the binary — and therefore `Application` — is never executed. The new test runs `bin/docs-builder list` as a subprocess and asserts it boots and registers `build:docs`. It fails without the fix (exit code 255, the fatal above) and passes with it.

Verified by hand too: a full `bin/docs-builder build:docs <source> <output> --symfony-version=4.0` now completes and writes the HTML files.

Full suite green: 69 tests, 156 assertions.