### PR TITLE
Pass the --symfony-version option to the build configuration

### DIFF
--- a/bin/docs-builder
+++ b/bin/docs-builder
@@ -17,10 +17,10 @@ use Symfony\Component\Console\Input\ArgvInput;
 use SymfonyDocsBuilder\Application;
 
 $input       = new ArgvInput();
-$version = $input->getParameterOption(['--symfony-version'], false === getenv('SYMFONY_VERSION') ? 'master' : getenv('SYMFONY_VERSION'));
+$version = $input->getParameterOption(['--symfony-version'], getenv('SYMFONY_VERSION') ?: null);
 
-if (!$version) {
-    throw new \Exception('Please pass a --symfony-version= flag or set a SYMFONY_VERSION environment variable to 4.0, master, etc.');
+if ('' === $version) {
+    throw new \Exception('The --symfony-version= flag and the SYMFONY_VERSION environment variable cannot be empty. Pass a version such as 6.4, 7.4, etc.');
 }
 
 $application = new Application($version);

--- a/src/Application.php
+++ b/src/Application.php
@@ -19,10 +19,15 @@ class Application
     private $application;
     private $buildConfig;
 
-    public function __construct(string $symfonyVersion)
+    public function __construct(?string $symfonyVersion = null)
     {
         $this->application = new BaseApplication();
         $this->buildConfig = new BuildConfig();
+
+        // when no version is given, the default of BuildConfig is kept
+        if (null !== $symfonyVersion) {
+            $this->buildConfig->setSymfonyVersion($symfonyVersion);
+        }
     }
 
     public function run(InputInterface $input): int
@@ -32,7 +37,7 @@ class Application
             null,
             InputOption::VALUE_REQUIRED,
             'The symfony version of the doc to parse.',
-            false === getenv('SYMFONY_VERSION') ? 'master' : getenv('SYMFONY_VERSION')
+            $this->buildConfig->getSymfonyVersion()
         );
         $this->application->getDefinition()->addOption($inputOption);
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -10,7 +10,9 @@
 namespace SymfonyDocsBuilder\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use SymfonyDocsBuilder\BuildConfig;
 
 /**
  * The rest of the test suite drives the command through CommandTester, so it
@@ -29,5 +31,60 @@ class ApplicationTest extends TestCase
             sprintf("The binary failed to run:\n%s", $process->getErrorOutput())
         );
         $this->assertStringContainsString('build:docs', $process->getOutput());
+    }
+
+    public function testTheSymfonyVersionOptionIsUsedToBuildTheDocs()
+    {
+        $this->assertStringContainsString(
+            'github.com/symfony/symfony/blob/6.4/src',
+            $this->buildAndGetHtml(['--symfony-version=6.4'])
+        );
+    }
+
+    public function testTheSymfonyVersionEnvVarIsUsedToBuildTheDocs()
+    {
+        $this->assertStringContainsString(
+            'github.com/symfony/symfony/blob/7.4/src',
+            $this->buildAndGetHtml([], ['SYMFONY_VERSION' => '7.4'])
+        );
+    }
+
+    public function testTheDefaultSymfonyVersionIsUsedWhenNoneIsGiven()
+    {
+        $this->assertStringContainsString(
+            sprintf('github.com/symfony/symfony/blob/%s/src', (new BuildConfig())->getSymfonyVersion()),
+            $this->buildAndGetHtml()
+        );
+    }
+
+    /**
+     * Builds the "main" fixture through the binary and returns the HTML of the
+     * page holding a :class: reference.
+     */
+    private function buildAndGetHtml(array $options = [], array $env = []): string
+    {
+        $outputDir = sprintf('%s/_output/application/%s', __DIR__, uniqid());
+
+        $process = new Process(
+            array_merge(
+                [\PHP_BINARY, __DIR__.'/../bin/docs-builder', 'build:docs', __DIR__.'/fixtures/source/main', $outputDir],
+                $options
+            ),
+            null,
+            $env
+        );
+        $process->run();
+
+        $this->assertSame(
+            0,
+            $process->getExitCode(),
+            sprintf("The binary failed to run:\n%s", $process->getErrorOutput())
+        );
+
+        $html = file_get_contents($outputDir.'/datetime.html');
+
+        (new Filesystem())->remove($outputDir);
+
+        return $html;
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Built on top of #209, since both touch `src/Application.php` and this PR extends the test file added there. Please merge #209 first — the diff shown here will shrink accordingly.

`Application::__construct()` takes a `$symfonyVersion`… and drops it on the floor. It's never passed to `BuildConfig`, so `--symfony-version` (and `SYMFONY_VERSION`) have no effect: every build silently uses `BuildConfig`'s own default of `4.4`.

Easy to see:

```
$ php bin/docs-builder build:docs docs/ output/ --symfony-version=6.4
$ grep -o 'symfony/symfony/blob/[0-9.]*' output/*.html
symfony/symfony/blob/4.4      # ← asked for 6.4
```

So every `:class:`, `:method:` and `:namespace:` link points at the wrong branch.

**The fix** wires the version into `BuildConfig` when one is given. After it, the same command yields `blob/6.4`, and `SYMFONY_VERSION=7.4` yields `blob/7.4`.

**On the default.** The binary used to fall back to `'master'` — a branch that doesn't exist on `symfony/symfony` anymore, and which would have produced 404 links the moment the value was actually honored. Rather than resurrect it, the fallback is now "no version given", which leaves `BuildConfig`'s default (`4.4`) in place: builds that pass no option keep behaving exactly as they do today. The option's displayed default now reads from `BuildConfig` too, so `--help` no longer advertises a value the builder doesn't use.

Happy to make the default something more current than `4.4` if you'd like — that felt like your call rather than mine, so I left it alone.

**Tests** cover the three paths through the binary: the option, the env var, and the default. The first two fail without the fix (the built HTML links to `4.4` instead of the requested branch).

Full suite green: 72 tests, 162 assertions.